### PR TITLE
Adds null support

### DIFF
--- a/ModernUO.Serialization.Annotations/CanBeNullAttribute.cs
+++ b/ModernUO.Serialization.Annotations/CanBeNullAttribute.cs
@@ -1,0 +1,27 @@
+﻿/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2022 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: CanBeNullAttribute.cs                                           *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System;
+
+namespace ModernUO.Serialization;
+
+/// <summary>
+/// Hints to the source generator that this field or property can be null.
+/// Note: This will change the serialization by prefixing the data with a boolean to indicate if it is null
+/// </summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+public class CanBeNullAttribute : Attribute
+{
+}

--- a/ModernUO.Serialization.Annotations/ModernUO.Serialization.Annotations.csproj
+++ b/ModernUO.Serialization.Annotations/ModernUO.Serialization.Annotations.csproj
@@ -5,8 +5,8 @@
         <PackageId>ModernUO.Serialization.Annotations</PackageId>
         <TargetFramework>net6.0</TargetFramework>
         <LangVersion>preview</LangVersion>
-        <AssemblyVersion>2.2.0</AssemblyVersion>
-        <PackageVersion>2.2.0</PackageVersion>
+        <AssemblyVersion>2.5.0</AssemblyVersion>
+        <PackageVersion>2.5.0</PackageVersion>
         <AssemblyName>ModernUO.Serialization.Annotations</AssemblyName>
         <RootNamespace>ModernUO.Serialization</RootNamespace>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/ModernUO.Serialization.Generator/ModernUO.Serialization.Generator.csproj
+++ b/ModernUO.Serialization.Generator/ModernUO.Serialization.Generator.csproj
@@ -4,8 +4,8 @@
         <PackageId>ModernUO.Serialization.Generator</PackageId>
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>preview</LangVersion>
-        <AssemblyVersion>2.4.3</AssemblyVersion>
-        <PackageVersion>2.4.3</PackageVersion>
+        <AssemblyVersion>2.5.0</AssemblyVersion>
+        <PackageVersion>2.5.0</PackageVersion>
         <AssemblyName>ModernUO.Serialization.Generator</AssemblyName>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/ArrayMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/ArrayMigrationRule.cs
@@ -85,12 +85,12 @@ public class ArrayMigrationRule : MigrationRule
         }
         var ruleArguments = property.RuleArguments;
         var canBeNull = ruleArguments![0] == "@CanBeNull";
-        var offset = canBeNull ? 1 : 0;
+        var index = canBeNull ? 1 : 0;
 
-        var arrayElementType = ruleArguments[offset];
-        var arrayElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments![offset + 1]];
-        var arrayElementRuleArguments = new string[ruleArguments.Length - 2 - offset];
-        Array.Copy(ruleArguments, 2, arrayElementRuleArguments, 0, ruleArguments.Length - 2 - offset);
+        var arrayElementType = ruleArguments[index++];
+        var arrayElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments![index++]];
+        var arrayElementRuleArguments = new string[ruleArguments.Length - index];
+        Array.Copy(ruleArguments, index, arrayElementRuleArguments, 0, ruleArguments.Length - index);
 
         var propertyName = property.FieldName ?? property.Name;
 
@@ -186,7 +186,7 @@ public class ArrayMigrationRule : MigrationRule
             var newIndent = $"{indent}    ";
             source.AppendLine($"{indent}if ({propertyName} != default)");
             source.AppendLine($"{indent}{{");
-            source.AppendLine($"{newIndent}writer.Write(false);");
+            source.AppendLine($"{newIndent}writer.Write(true);");
             GenerateSerialize(
                 source,
                 newIndent,

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/ArrayMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/ArrayMigrationRule.cs
@@ -52,18 +52,17 @@ public class ArrayMigrationRule : MigrationRule
         var length = serializableArrayType.RuleArguments?.Length ?? 0;
         var canBeNull = attributes.Any(a => a.IsCanBeNull(compilation));
         ruleArguments = new string[length + 2 + (canBeNull ? 1 : 0)];
-        var offset = 0;
+        var index = 0;
         if (canBeNull)
         {
-            ruleArguments[0] = "@CanBeNull";
-            offset++;
+            ruleArguments[index++] = "@CanBeNull";
         }
 
-        ruleArguments[offset] = arrayTypeSymbol.ElementType.ToDisplayString();
-        ruleArguments[offset + 1] = serializableArrayType.Rule;
+        ruleArguments[index++] = arrayTypeSymbol.ElementType.ToDisplayString();
+        ruleArguments[index++] = serializableArrayType.Rule;
         if (length > 0)
         {
-            Array.Copy(serializableArrayType.RuleArguments!, 0, ruleArguments, 2 + offset, length);
+            Array.Copy(serializableArrayType.RuleArguments!, 0, ruleArguments, index, length);
         }
 
         return true;
@@ -187,6 +186,7 @@ public class ArrayMigrationRule : MigrationRule
             var newIndent = $"{indent}    ";
             source.AppendLine($"{indent}if ({propertyName} != default)");
             source.AppendLine($"{indent}{{");
+            source.AppendLine($"{newIndent}writer.Write(false);");
             GenerateSerialize(
                 source,
                 newIndent,

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/ArrayMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/ArrayMigrationRule.cs
@@ -109,6 +109,10 @@ public class ArrayMigrationRule : MigrationRule
                 arrayElementRuleArguments
             );
             source.AppendLine($"{indent}}}");
+            source.AppendLine($"{indent}else");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{indent}    {propertyName} = default;");
+            source.AppendLine($"{indent}}}");
         }
         else
         {

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/ArrayMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/ArrayMigrationRule.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
@@ -48,13 +49,21 @@ public class ArrayMigrationRule : MigrationRule
             null
         );
 
-        var length = serializableArrayType.RuleArguments?.Length?? 0;
-        ruleArguments = new string[length + 2];
-        ruleArguments[0] = arrayTypeSymbol.ElementType.ToDisplayString();
-        ruleArguments[1] = serializableArrayType.Rule;
+        var length = serializableArrayType.RuleArguments?.Length ?? 0;
+        var canBeNull = attributes.Any(a => a.IsCanBeNull(compilation));
+        ruleArguments = new string[length + 2 + (canBeNull ? 1 : 0)];
+        var offset = 0;
+        if (canBeNull)
+        {
+            ruleArguments[0] = "@CanBeNull";
+            offset++;
+        }
+
+        ruleArguments[offset] = arrayTypeSymbol.ElementType.ToDisplayString();
+        ruleArguments[offset + 1] = serializableArrayType.Rule;
         if (length > 0)
         {
-            Array.Copy(serializableArrayType.RuleArguments!, 0, ruleArguments, 2, length);
+            Array.Copy(serializableArrayType.RuleArguments!, 0, ruleArguments, 2 + offset, length);
         }
 
         return true;
@@ -76,23 +85,71 @@ public class ArrayMigrationRule : MigrationRule
             throw new ArgumentException($"Invalid rule applied to property {ruleName}. Expecting {expectedRule}, but received {ruleName}.");
         }
         var ruleArguments = property.RuleArguments;
-        var arrayElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments![1]];
-        var arrayElementRuleArguments = new string[ruleArguments.Length - 2];
-        Array.Copy(ruleArguments, 2, arrayElementRuleArguments, 0, ruleArguments.Length - 2);
+        var canBeNull = ruleArguments![0] == "@CanBeNull";
+        var offset = canBeNull ? 1 : 0;
+
+        var arrayElementType = ruleArguments[offset];
+        var arrayElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments![offset + 1]];
+        var arrayElementRuleArguments = new string[ruleArguments.Length - 2 - offset];
+        Array.Copy(ruleArguments, 2, arrayElementRuleArguments, 0, ruleArguments.Length - 2 - offset);
 
         var propertyName = property.FieldName ?? property.Name;
-        var propertyIndex = $"{property.Name}Index";
-        source.AppendLine($"{indent}{propertyName} = new {ruleArguments[0]}[reader.ReadEncodedInt()];");
-        source.AppendLine($"{indent}for (var {propertyIndex} = 0; {propertyIndex} < {propertyName}.Length; {propertyIndex}++)");
-        source.AppendLine($"{indent}{{");
+
+        if (canBeNull)
+        {
+            source.AppendLine($"{indent}if (reader.ReadBool())");
+            source.AppendLine($"{indent}{{");
+            GenerateDeserialize(
+                source,
+                compilation,
+                $"{indent}    ",
+                propertyName,
+                parentReference,
+                arrayElementType,
+                arrayElementRule,
+                arrayElementRuleArguments
+            );
+            source.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            GenerateDeserialize(
+                source,
+                compilation,
+                indent,
+                propertyName,
+                parentReference,
+                arrayElementType,
+                arrayElementRule,
+                arrayElementRuleArguments
+            );
+        }
+    }
+
+    private static void GenerateDeserialize(
+        StringBuilder source,
+        Compilation compilation,
+        string indent,
+        string propertyName,
+        string parentReference,
+        string arrayElementType,
+        ISerializableMigrationRule arrayElementRule,
+        string[] arrayElementRuleArguments
+    )
+    {
+        var propertyIndex = $"{propertyName}Index";
 
         var serializableArrayElement = new SerializableProperty
         {
             Name = $"{propertyName}[{propertyIndex}]",
-            Type = ruleArguments[0],
+            Type = arrayElementType,
             Rule = arrayElementRule.RuleName,
             RuleArguments = arrayElementRuleArguments
         };
+
+        source.AppendLine($"{indent}{propertyName} = new {arrayElementType}[reader.ReadEncodedInt()];");
+        source.AppendLine($"{indent}for (var {propertyIndex} = 0; {propertyIndex} < {propertyName}.Length; {propertyIndex}++)");
+        source.AppendLine($"{indent}{{");
 
         arrayElementRule.GenerateDeserializationMethod(
             source,
@@ -115,11 +172,57 @@ public class ArrayMigrationRule : MigrationRule
         }
 
         var ruleArguments = property.RuleArguments;
-        var arrayElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments![1]];
-        var arrayElementRuleArguments = new string[ruleArguments.Length - 2];
-        Array.Copy(ruleArguments, 2, arrayElementRuleArguments, 0, ruleArguments.Length - 2);
+        var canBeNull = ruleArguments![0] == "@CanBeNull";
+        var offset = canBeNull ? 1 : 0;
+
+        var arrayElementType = ruleArguments[offset];
+        var arrayElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments![offset + 1]];
+        var arrayElementRuleArguments = new string[ruleArguments.Length - 2 - offset];
+        Array.Copy(ruleArguments, 2, arrayElementRuleArguments, 0, ruleArguments.Length - 2 - offset);
 
         var propertyName = property.FieldName ?? property.Name;
+
+        if (canBeNull)
+        {
+            var newIndent = $"{indent}    ";
+            source.AppendLine($"{indent}if ({propertyName} != default)");
+            source.AppendLine($"{indent}{{");
+            GenerateSerialize(
+                source,
+                newIndent,
+                propertyName,
+                arrayElementType,
+                arrayElementRule,
+                arrayElementRuleArguments
+            );
+            source.AppendLine($"{indent}}}");
+            source.AppendLine($"{indent}else");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{newIndent}writer.Write(false);");
+            source.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            GenerateSerialize(
+                source,
+                indent,
+                propertyName,
+                arrayElementType,
+                arrayElementRule,
+                arrayElementRuleArguments
+            );
+        }
+    }
+
+    private static void GenerateSerialize(
+        StringBuilder source,
+        string indent,
+        string propertyName,
+        string arrayElementType,
+        ISerializableMigrationRule arrayElementRule,
+        string[] arrayElementRuleArguments
+    )
+    {
         var propertyIndex = $"{propertyName}Index";
         var propertyLength = $"{propertyName}Length";
         source.AppendLine($"{indent}var {propertyLength} = {propertyName}?.Length ?? 0;");
@@ -130,7 +233,7 @@ public class ArrayMigrationRule : MigrationRule
         var serializableArrayElement = new SerializableProperty
         {
             Name = $"{propertyName}![{propertyIndex}]",
-            Type = ruleArguments[0],
+            Type = arrayElementType,
             Rule = arrayElementRule.RuleName,
             RuleArguments = arrayElementRuleArguments
         };

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/DictionaryMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/DictionaryMigrationRule.cs
@@ -169,6 +169,10 @@ public class DictionaryMigrationRule : MigrationRule
                 valueRuleArguments
             );
             source.AppendLine($"{indent}}}");
+            source.AppendLine($"{indent}else");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{indent}    {propertyName} = default;");
+            source.AppendLine($"{indent}}}");
         }
         else
         {

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/DictionaryMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/DictionaryMigrationRule.cs
@@ -121,7 +121,7 @@ public class DictionaryMigrationRule : MigrationRule
         }
 
         var ruleArguments = property.RuleArguments;
-        var index = property.RuleArguments![0] == "@Tidy" ? 1 : 0;
+        var index = property.RuleArguments![0] is "@Tidy" or "" ? 1 : 0; // Skip the blank argument option
         var canBeNull = property.RuleArguments[index] == "@CanBeNull";
 
         if (canBeNull)
@@ -261,7 +261,7 @@ public class DictionaryMigrationRule : MigrationRule
 
         var ruleArguments = property.RuleArguments;
         var shouldTidy = property.RuleArguments![0] == "@Tidy";
-        var index = shouldTidy ? 1 : 0;
+        var index = shouldTidy || property.RuleArguments![0] == "" ? 1 : 0; // Skip the empty argyment
         var canBeNull = property.RuleArguments[index] == "@CanBeNull";
 
         if (canBeNull)
@@ -295,7 +295,7 @@ public class DictionaryMigrationRule : MigrationRule
             var newIndent = $"{indent}    ";
             source.AppendLine($"{indent}if ({propertyName} != default)");
             source.AppendLine($"{indent}{{");
-            source.AppendLine($"{newIndent}writer.Write(false);");
+            source.AppendLine($"{newIndent}writer.Write(true);");
             GenerateSerialize(
                 source,
                 newIndent,
@@ -341,7 +341,8 @@ public class DictionaryMigrationRule : MigrationRule
         ISerializableMigrationRule keyElementRule,
         string[] keyRuleArguments,
         ISerializableMigrationRule valueElementRule,
-        string[] valueRuleArguments)
+        string[] valueRuleArguments
+    )
     {
         var propertyKeyEntry = $"{propertyName}Key";
         var propertyValueEntry = $"{propertyName}Value";

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/HashSetMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/HashSetMigrationRule.cs
@@ -51,21 +51,29 @@ public class HashSetMigrationRule : MigrationRule
             null
         );
 
-        var extraOptions = "";
-        if (attributes.Any(a => a.IsTidy(compilation)))
-        {
-            extraOptions += "@Tidy";
-        }
+        var isTidy = attributes.Any(a => a.IsTidy(compilation));
+        var canBeNull = attributes.Any(a => a.IsCanBeNull(compilation));
 
         var length = serializableSetType.RuleArguments?.Length ?? 0;
-        ruleArguments = new string[length + 3];
-        ruleArguments[0] = extraOptions;
-        ruleArguments[1] = setTypeSymbol.ToDisplayString();
-        ruleArguments[2] = serializableSetType.Rule;
+        ruleArguments = new string[(isTidy ? 1 : 0) + (canBeNull ? 1 : 0) + 2 + length];
+
+        var index = 0;
+
+        if (isTidy)
+        {
+            ruleArguments[index++] = "@Tidy";
+        }
+
+        if (canBeNull)
+        {
+            ruleArguments[index++] = "@CanBeNull";
+        }
+        ruleArguments[index++] = setTypeSymbol.ToDisplayString();
+        ruleArguments[index++] = serializableSetType.Rule;
 
         if (length > 0)
         {
-            Array.Copy(serializableSetType.RuleArguments, 0, ruleArguments, 3, length);
+            Array.Copy(serializableSetType.RuleArguments!, 0, ruleArguments, index, length);
         }
 
         return true;
@@ -88,28 +96,78 @@ public class HashSetMigrationRule : MigrationRule
         }
 
         var ruleArguments = property.RuleArguments;
-        var hasExtraOptions = ruleArguments![0] == "" || ruleArguments[0].StartsWith("@", StringComparison.Ordinal);
-        var argumentsOffset = hasExtraOptions ? 1 : 0;
+        var index = property.RuleArguments![0] is "@Tidy" or "" ? 1 : 0; // Skip the blank argument option
+        var canBeNull = property.RuleArguments[index] == "@CanBeNull";
 
-        var setElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments[1 + argumentsOffset]];
-        var setElementRuleArguments = new string[ruleArguments.Length - 2 - argumentsOffset];
-        Array.Copy(ruleArguments, 2 + argumentsOffset, setElementRuleArguments, 0, ruleArguments.Length - 2 - argumentsOffset);
+        if (canBeNull)
+        {
+            index++;
+        }
+
+        var setElementType = ruleArguments![index++];
+        var setElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments[index++]];
+        var setElementRuleArguments = new string[ruleArguments.Length - index];
+
+        Array.Copy(ruleArguments, index, setElementRuleArguments, 0, ruleArguments.Length - index);
 
         var propertyName = property.FieldName ?? property.Name;
+
+        if (canBeNull)
+        {
+            source.AppendLine($"{indent}if (reader.ReadBool())");
+            source.AppendLine($"{indent}{{");
+            GenerateDeserialize(
+                source,
+                compilation,
+                $"{indent}    ",
+                propertyName,
+                parentReference,
+                setElementType,
+                setElementRule,
+                setElementRuleArguments
+            );
+            source.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            GenerateDeserialize(
+                source,
+                compilation,
+                indent,
+                propertyName,
+                parentReference,
+                setElementType,
+                setElementRule,
+                setElementRuleArguments
+            );
+        }
+    }
+
+    private static void GenerateDeserialize(
+        StringBuilder source,
+        Compilation compilation,
+        string indent,
+        string propertyName,
+        string parentReference,
+        string setElementType,
+        ISerializableMigrationRule setElementRule,
+        string[] setElementRuleArguments
+    )
+    {
         var propertyIndex = $"{propertyName}Index";
         var propertyEntry = $"{propertyName}Entry";
         var propertyCount = $"{propertyName}Count";
 
-        source.AppendLine($"{indent}{ruleArguments[argumentsOffset]} {propertyEntry};");
+        source.AppendLine($"{indent}{setElementType} {propertyEntry};");
         source.AppendLine($"{indent}var {propertyCount} = reader.ReadEncodedInt();");
-        source.AppendLine($"{indent}{propertyName} = new System.Collections.Generic.HashSet<{ruleArguments[argumentsOffset]}>({propertyCount});");
+        source.AppendLine($"{indent}{propertyName} = new System.Collections.Generic.HashSet<{setElementType}>({propertyCount});");
         source.AppendLine($"{indent}for (var {propertyIndex} = 0; {propertyIndex} < {propertyCount}; {propertyIndex}++)");
         source.AppendLine($"{indent}{{");
 
         var serializableSetElement = new SerializableProperty
         {
             Name = propertyEntry,
-            Type = ruleArguments[argumentsOffset],
+            Type = setElementType,
             Rule = setElementRule.RuleName,
             RuleArguments = setElementRuleArguments
         };
@@ -136,15 +194,67 @@ public class HashSetMigrationRule : MigrationRule
         }
 
         var ruleArguments = property.RuleArguments;
-        var hasExtraOptions = ruleArguments![0] == "" || ruleArguments[0].StartsWith("@", StringComparison.Ordinal);
-        var shouldTidy = hasExtraOptions && ruleArguments[0].Contains("@Tidy");
-        var argumentsOffset = hasExtraOptions ? 1 : 0;
+        var shouldTidy = property.RuleArguments![0] == "@Tidy";
+        var index = shouldTidy || property.RuleArguments![0] == "" ? 1 : 0; // Skip the empty argyment
+        var canBeNull = property.RuleArguments[index] == "@CanBeNull";
 
-        var setElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments[1 + argumentsOffset]];
-        var setElementRuleArguments = new string[ruleArguments.Length - 2 - argumentsOffset];
-        Array.Copy(ruleArguments, 2 + argumentsOffset, setElementRuleArguments, 0, ruleArguments.Length - 2 - argumentsOffset);
+        if (canBeNull)
+        {
+            index++;
+        }
+
+        var setElementType = ruleArguments![index++];
+        var setElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments[index++]];
+        var setElementRuleArguments = new string[ruleArguments.Length - index];
+        Array.Copy(ruleArguments, index, setElementRuleArguments, 0, ruleArguments.Length - index);
 
         var propertyName = property.FieldName ?? property.Name;
+
+        if (canBeNull)
+        {
+            var newIndent = $"{indent}    ";
+            source.AppendLine($"{indent}if ({propertyName} != default)");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{newIndent}writer.Write(true);");
+            GenerateSerialize(
+                source,
+                newIndent,
+                propertyName,
+                shouldTidy,
+                setElementType,
+                setElementRule,
+                setElementRuleArguments
+            );
+            source.AppendLine($"{indent}}}");
+            source.AppendLine($"{indent}else");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{newIndent}writer.Write(false);");
+            source.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            GenerateSerialize(
+                source,
+                indent,
+                propertyName,
+                shouldTidy,
+                setElementType,
+                setElementRule,
+                setElementRuleArguments
+            );
+        }
+    }
+
+    private static void GenerateSerialize(
+        StringBuilder source,
+        string indent,
+        string propertyName,
+        bool shouldTidy,
+        string setElementType,
+        ISerializableMigrationRule setElementRule,
+        string[] setElementRuleArguments
+    )
+    {
         var propertyEntry = $"{propertyName}Entry";
         var propertyCount = $"{propertyName}Count";
 
@@ -162,7 +272,7 @@ public class HashSetMigrationRule : MigrationRule
         var serializableSetElement = new SerializableProperty
         {
             Name = propertyEntry,
-            Type = ruleArguments[argumentsOffset],
+            Type = setElementType,
             Rule = setElementRule.RuleName,
             RuleArguments = setElementRuleArguments
         };

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/HashSetMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/HashSetMigrationRule.cs
@@ -127,6 +127,10 @@ public class HashSetMigrationRule : MigrationRule
                 setElementRuleArguments
             );
             source.AppendLine($"{indent}}}");
+            source.AppendLine($"{indent}else");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{indent}    {propertyName} = default;");
+            source.AppendLine($"{indent}}}");
         }
         else
         {

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/KeyValuePairMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/KeyValuePairMigrationRule.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
@@ -64,11 +65,18 @@ public class KeyValuePairMigrationRule : MigrationRule
 
         var keyArgumentsLength = keySerializedProperty.RuleArguments?.Length ?? 0;
         var valueArgumentsLength = valueSerializedProperty.RuleArguments?.Length ?? 0;
+        var canBeNull = attributes.Any(a => a.IsCanBeNull(compilation));
+
+        ruleArguments = new string[(canBeNull ? 1 : 0) + 6 + keyArgumentsLength + valueArgumentsLength];
+
         var index = 0;
 
+        if (canBeNull)
+        {
+            ruleArguments[index++] = "@CanBeNull";
+        }
+
         // Key
-        ruleArguments = new string[6 + keyArgumentsLength + valueArgumentsLength];
-        ruleArguments[index++] = ""; // Extra options
         ruleArguments[index++] = keySymbolType.ToDisplayString();
         ruleArguments[index++] = keySerializedProperty.Rule;
         ruleArguments[index++] = keyArgumentsLength.ToString();
@@ -81,6 +89,7 @@ public class KeyValuePairMigrationRule : MigrationRule
         // Value
         ruleArguments[index++] = valueSymbolType.ToDisplayString();
         ruleArguments[index++] = valueSerializedProperty.Rule;
+        ruleArguments[index++] = valueArgumentsLength.ToString();
 
         if (valueArgumentsLength > 0)
         {
@@ -107,7 +116,9 @@ public class KeyValuePairMigrationRule : MigrationRule
         }
 
         var ruleArguments = property.RuleArguments;
-        var index = 1; // skip extra options
+        var canBeNull = property.RuleArguments![0] == "@CanBeNull";
+        var index = canBeNull || property.RuleArguments![0] == "" ? 1 : 0; // Skip the blank argument option
+
         var keyType = ruleArguments![index++];
         var keyRule = SerializableMigrationRulesEngine.Rules[ruleArguments[index++]];
         var keyRuleArguments = new string[int.Parse(ruleArguments[index++])];
@@ -118,6 +129,68 @@ public class KeyValuePairMigrationRule : MigrationRule
             index += keyRuleArguments.Length;
         }
 
+        var valueType = ruleArguments[index++];
+        var valueRule = SerializableMigrationRulesEngine.Rules[ruleArguments[index++]];
+        var valueRuleArguments = new string[int.Parse(ruleArguments[index++])];
+
+        if (valueRuleArguments.Length > 0)
+        {
+            Array.Copy(ruleArguments, index, valueRuleArguments, 0, valueRuleArguments.Length);
+        }
+
+        var propertyName = property.FieldName ?? property.Name;
+
+        if (canBeNull)
+        {
+            source.AppendLine($"{indent}if (reader.ReadBool())");
+            source.AppendLine($"{indent}{{");
+            GenerateDeserialize(
+                source,
+                compilation,
+                $"{indent}    ",
+                propertyName,
+                parentReference,
+                keyType,
+                valueType,
+                keyRule,
+                keyRuleArguments,
+                valueRule,
+                valueRuleArguments
+            );
+            source.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            GenerateDeserialize(
+                source,
+                compilation,
+                indent,
+                propertyName,
+                parentReference,
+                keyType,
+                valueType,
+                keyRule,
+                keyRuleArguments,
+                valueRule,
+                valueRuleArguments
+            );
+        }
+    }
+
+    private static void GenerateDeserialize(
+        StringBuilder source,
+        Compilation compilation,
+        string indent,
+        string propertyName,
+        string parentReference,
+        string keyType,
+        string valueType,
+        ISerializableMigrationRule keyRule,
+        string[] keyRuleArguments,
+        ISerializableMigrationRule valueRule,
+        string[] valueRuleArguments
+    )
+    {
         var serializableKeyProperty = new SerializableProperty
         {
             Name = "key",
@@ -133,15 +206,6 @@ public class KeyValuePairMigrationRule : MigrationRule
             serializableKeyProperty,
             parentReference
         );
-
-        var valueType = ruleArguments[index++];
-        var valueRule = SerializableMigrationRulesEngine.Rules[ruleArguments[index++]];
-        var valueRuleArguments = new string[int.Parse(ruleArguments[index++])];
-
-        if (valueRuleArguments.Length > 0)
-        {
-            Array.Copy(ruleArguments, index, valueRuleArguments, 0, valueRuleArguments.Length);
-        }
 
         var serializableValueProperty = new SerializableProperty
         {
@@ -159,7 +223,6 @@ public class KeyValuePairMigrationRule : MigrationRule
             parentReference
         );
 
-        var propertyName = property.FieldName ?? property.Name;
         source.AppendLine(
             $"{indent}{propertyName} = new {SymbolMetadata.KEYVALUEPAIR_STRUCT}<{keyType}, {valueType}>(key, value);"
         );
@@ -175,7 +238,9 @@ public class KeyValuePairMigrationRule : MigrationRule
         }
 
         var ruleArguments = property.RuleArguments;
-        var index = 1; // skip extra options
+        var canBeNull = property.RuleArguments![0] == "@CanBeNull";
+        var index = canBeNull || property.RuleArguments![0] == "" ? 1 : 0; // Skip the blank argument option
+
         var keyType = ruleArguments![index++];
         var keyRule = SerializableMigrationRulesEngine.Rules[ruleArguments[index++]];
         var keyRuleArguments = new string[int.Parse(ruleArguments[index++])];
@@ -186,8 +251,68 @@ public class KeyValuePairMigrationRule : MigrationRule
             index += keyRuleArguments.Length;
         }
 
+        var valueType = ruleArguments[index++];
+        var valueRule = SerializableMigrationRulesEngine.Rules[ruleArguments[index++]];
+        var valueRuleArguments = new string[int.Parse(ruleArguments[index++])];
+
+        if (valueRuleArguments.Length > 0)
+        {
+            Array.Copy(ruleArguments, index, valueRuleArguments, 0, valueRuleArguments.Length);
+        }
+
         var propertyName = property.FieldName ?? property.Name;
 
+        if (canBeNull)
+        {
+            var newIndent = $"{indent}    ";
+            source.AppendLine($"{indent}if ({propertyName} != default)");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{newIndent}writer.Write(true);");
+            GenerateSerialize(
+                source,
+                newIndent,
+                propertyName,
+                keyType,
+                valueType,
+                keyRule,
+                keyRuleArguments,
+                valueRule,
+                valueRuleArguments
+            );
+            source.AppendLine($"{indent}}}");
+            source.AppendLine($"{indent}else");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{newIndent}writer.Write(false);");
+            source.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            GenerateSerialize(
+                source,
+                indent,
+                propertyName,
+                keyType,
+                valueType,
+                keyRule,
+                keyRuleArguments,
+                valueRule,
+                valueRuleArguments
+            );
+        }
+    }
+
+    private static void GenerateSerialize(
+        StringBuilder source,
+        string indent,
+        string propertyName,
+        string keyType,
+        string valueType,
+        ISerializableMigrationRule keyRule,
+        string[] keyRuleArguments,
+        ISerializableMigrationRule valueRule,
+        string[] valueRuleArguments
+    )
+    {
         var serializableKeyProperty = new SerializableProperty
         {
             Name = $"{propertyName}.Key",
@@ -201,15 +326,6 @@ public class KeyValuePairMigrationRule : MigrationRule
             indent,
             serializableKeyProperty
         );
-
-        var valueType = ruleArguments[index++];
-        var valueRule = SerializableMigrationRulesEngine.Rules[ruleArguments[index++]];
-        var valueRuleArguments = new string[int.Parse(ruleArguments[index++])];
-
-        if (valueRuleArguments.Length > 0)
-        {
-            Array.Copy(ruleArguments, index, valueRuleArguments, 0, valueRuleArguments.Length);
-        }
 
         var serializableValueProperty = new SerializableProperty
         {

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/KeyValuePairMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/KeyValuePairMigrationRule.cs
@@ -65,16 +65,10 @@ public class KeyValuePairMigrationRule : MigrationRule
 
         var keyArgumentsLength = keySerializedProperty.RuleArguments?.Length ?? 0;
         var valueArgumentsLength = valueSerializedProperty.RuleArguments?.Length ?? 0;
-        var canBeNull = attributes.Any(a => a.IsCanBeNull(compilation));
 
-        ruleArguments = new string[(canBeNull ? 1 : 0) + 6 + keyArgumentsLength + valueArgumentsLength];
+        ruleArguments = new string[6 + keyArgumentsLength + valueArgumentsLength];
 
         var index = 0;
-
-        if (canBeNull)
-        {
-            ruleArguments[index++] = "@CanBeNull";
-        }
 
         // Key
         ruleArguments[index++] = keySymbolType.ToDisplayString();
@@ -116,8 +110,7 @@ public class KeyValuePairMigrationRule : MigrationRule
         }
 
         var ruleArguments = property.RuleArguments;
-        var canBeNull = property.RuleArguments![0] == "@CanBeNull";
-        var index = canBeNull || property.RuleArguments![0] == "" ? 1 : 0; // Skip the blank argument option
+        var index = property.RuleArguments![0] == "" ? 1 : 0; // Skip the blank argument option
 
         var keyType = ruleArguments![index++];
         var keyRule = SerializableMigrationRulesEngine.Rules[ruleArguments[index++]];
@@ -140,41 +133,19 @@ public class KeyValuePairMigrationRule : MigrationRule
 
         var propertyName = property.FieldName ?? property.Name;
 
-        if (canBeNull)
-        {
-            source.AppendLine($"{indent}if (reader.ReadBool())");
-            source.AppendLine($"{indent}{{");
-            GenerateDeserialize(
-                source,
-                compilation,
-                $"{indent}    ",
-                propertyName,
-                parentReference,
-                keyType,
-                valueType,
-                keyRule,
-                keyRuleArguments,
-                valueRule,
-                valueRuleArguments
-            );
-            source.AppendLine($"{indent}}}");
-        }
-        else
-        {
-            GenerateDeserialize(
-                source,
-                compilation,
-                indent,
-                propertyName,
-                parentReference,
-                keyType,
-                valueType,
-                keyRule,
-                keyRuleArguments,
-                valueRule,
-                valueRuleArguments
-            );
-        }
+        GenerateDeserialize(
+            source,
+            compilation,
+            indent,
+            propertyName,
+            parentReference,
+            keyType,
+            valueType,
+            keyRule,
+            keyRuleArguments,
+            valueRule,
+            valueRuleArguments
+        );
     }
 
     private static void GenerateDeserialize(
@@ -238,8 +209,7 @@ public class KeyValuePairMigrationRule : MigrationRule
         }
 
         var ruleArguments = property.RuleArguments;
-        var canBeNull = property.RuleArguments![0] == "@CanBeNull";
-        var index = canBeNull || property.RuleArguments![0] == "" ? 1 : 0; // Skip the blank argument option
+        var index = property.RuleArguments![0] == "" ? 1 : 0; // Skip the blank argument option
 
         var keyType = ruleArguments![index++];
         var keyRule = SerializableMigrationRulesEngine.Rules[ruleArguments[index++]];
@@ -262,43 +232,17 @@ public class KeyValuePairMigrationRule : MigrationRule
 
         var propertyName = property.FieldName ?? property.Name;
 
-        if (canBeNull)
-        {
-            var newIndent = $"{indent}    ";
-            source.AppendLine($"{indent}if ({propertyName} != default)");
-            source.AppendLine($"{indent}{{");
-            source.AppendLine($"{newIndent}writer.Write(true);");
-            GenerateSerialize(
-                source,
-                newIndent,
-                propertyName,
-                keyType,
-                valueType,
-                keyRule,
-                keyRuleArguments,
-                valueRule,
-                valueRuleArguments
-            );
-            source.AppendLine($"{indent}}}");
-            source.AppendLine($"{indent}else");
-            source.AppendLine($"{indent}{{");
-            source.AppendLine($"{newIndent}writer.Write(false);");
-            source.AppendLine($"{indent}}}");
-        }
-        else
-        {
-            GenerateSerialize(
-                source,
-                indent,
-                propertyName,
-                keyType,
-                valueType,
-                keyRule,
-                keyRuleArguments,
-                valueRule,
-                valueRuleArguments
-            );
-        }
+        GenerateSerialize(
+            source,
+            indent,
+            propertyName,
+            keyType,
+            valueType,
+            keyRule,
+            keyRuleArguments,
+            valueRule,
+            valueRuleArguments
+        );
     }
 
     private static void GenerateSerialize(

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/ListMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/ListMigrationRule.cs
@@ -51,21 +51,29 @@ public class ListMigrationRule : MigrationRule
             null
         );
 
-        var extraOptions = "";
-        if (attributes.Any(a => a.IsTidy(compilation)))
-        {
-            extraOptions += "@Tidy";
-        }
+        var isTidy = attributes.Any(a => a.IsTidy(compilation));
+        var canBeNull = attributes.Any(a => a.IsCanBeNull(compilation));
 
         var length = serializableListType.RuleArguments?.Length ?? 0;
-        ruleArguments = new string[length + 3];
-        ruleArguments[0] = extraOptions;
-        ruleArguments[1] = listTypeSymbol.ToDisplayString();
-        ruleArguments[2] = serializableListType.Rule;
+        ruleArguments = new string[(isTidy ? 1 : 0) + (canBeNull ? 1 : 0) + 2 + length];
+
+        var index = 0;
+
+        if (isTidy)
+        {
+            ruleArguments[index++] = "@Tidy";
+        }
+
+        if (canBeNull)
+        {
+            ruleArguments[index++] = "@CanBeNull";
+        }
+        ruleArguments[index++] = listTypeSymbol.ToDisplayString();
+        ruleArguments[index++] = serializableListType.Rule;
 
         if (length > 0)
         {
-            Array.Copy(serializableListType.RuleArguments!, 0, ruleArguments, 3, length);
+            Array.Copy(serializableListType.RuleArguments!, 0, ruleArguments, index, length);
         }
 
         return true;
@@ -88,29 +96,77 @@ public class ListMigrationRule : MigrationRule
         }
 
         var ruleArguments = property.RuleArguments;
-        var hasExtraOptions = ruleArguments![0] == "" || ruleArguments[0].StartsWith("@", StringComparison.Ordinal);
-        var argumentsOffset = hasExtraOptions ? 1 : 0;
+        var index = property.RuleArguments![0] is "@Tidy" or "" ? 1 : 0; // Skip the blank argument option
+        var canBeNull = property.RuleArguments[index] == "@CanBeNull";
 
-        var listElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments[argumentsOffset + 1]];
+        if (canBeNull)
+        {
+            index++;
+        }
 
-        var listElementRuleArguments = new string[ruleArguments.Length - 2 - argumentsOffset];
-        Array.Copy(ruleArguments, 2 + argumentsOffset, listElementRuleArguments, 0, ruleArguments.Length - 2 - argumentsOffset);
+        var listElementType = ruleArguments![index++];
+        var listElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments[index++]];
+        var listElementRuleArguments = new string[ruleArguments.Length - index];
+        Array.Copy(ruleArguments, index, listElementRuleArguments, 0, ruleArguments.Length - index);
 
         var propertyName = property.FieldName ?? property.Name;
+
+        if (canBeNull)
+        {
+            source.AppendLine($"{indent}if (reader.ReadBool())");
+            source.AppendLine($"{indent}{{");
+            GenerateDeserialize(
+                source,
+                compilation,
+                $"{indent}    ",
+                propertyName,
+                parentReference,
+                listElementType,
+                listElementRule,
+                listElementRuleArguments
+            );
+            source.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            GenerateDeserialize(
+                source,
+                compilation,
+                indent,
+                propertyName,
+                parentReference,
+                listElementType,
+                listElementRule,
+                listElementRuleArguments
+            );
+        }
+    }
+
+    private static void GenerateDeserialize(
+        StringBuilder source,
+        Compilation compilation,
+        string indent,
+        string propertyName,
+        string parentReference,
+        string listElementType,
+        ISerializableMigrationRule listElementRule,
+        string[] listElementRuleArguments
+    )
+    {
         var propertyIndex = $"{propertyName}Index";
         var propertyEntry = $"{propertyName}Entry";
         var propertyCount = $"{propertyName}Count";
 
-        source.AppendLine($"{indent}{ruleArguments[argumentsOffset]} {propertyEntry};");
+        source.AppendLine($"{indent}{listElementType} {propertyEntry};");
         source.AppendLine($"{indent}var {propertyCount} = reader.ReadEncodedInt();");
-        source.AppendLine($"{indent}{propertyName} = new System.Collections.Generic.List<{ruleArguments[argumentsOffset]}>({propertyCount});");
+        source.AppendLine($"{indent}{propertyName} = new System.Collections.Generic.List<{listElementType}>({propertyCount});");
         source.AppendLine($"{indent}for (var {propertyIndex} = 0; {propertyIndex} < {propertyCount}; {propertyIndex}++)");
         source.AppendLine($"{indent}{{");
 
         var serializableListElement = new SerializableProperty
         {
             Name = propertyEntry,
-            Type = ruleArguments[argumentsOffset],
+            Type = listElementType,
             Rule = listElementRule.RuleName,
             RuleArguments = listElementRuleArguments
         };
@@ -137,15 +193,67 @@ public class ListMigrationRule : MigrationRule
         }
 
         var ruleArguments = property.RuleArguments;
-        var hasExtraOptions = ruleArguments![0] == "" || ruleArguments[0].StartsWith("@", StringComparison.Ordinal);
-        var shouldTidy = hasExtraOptions && ruleArguments[0].Contains("@Tidy");
-        var argumentsOffset = hasExtraOptions ? 1 : 0;
+        var shouldTidy = property.RuleArguments![0] == "@Tidy";
+        var index = shouldTidy || property.RuleArguments![0] == "" ? 1 : 0; // Skip the empty argyment
+        var canBeNull = property.RuleArguments[index] == "@CanBeNull";
 
-        var listElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments[1 + argumentsOffset]];
-        var listElementRuleArguments = new string[ruleArguments.Length - 2 - argumentsOffset];
-        Array.Copy(ruleArguments, 2 + argumentsOffset, listElementRuleArguments, 0, ruleArguments.Length - 2 - argumentsOffset);
+        if (canBeNull)
+        {
+            index++;
+        }
+
+        var listElementType = ruleArguments![index++];
+        var listElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments[index++]];
+        var listElementRuleArguments = new string[ruleArguments.Length - index];
+        Array.Copy(ruleArguments, index, listElementRuleArguments, 0, ruleArguments.Length - index);
 
         var propertyName = property.FieldName ?? property.Name;
+
+        if (canBeNull)
+        {
+            var newIndent = $"{indent}    ";
+            source.AppendLine($"{indent}if ({propertyName} != default)");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{newIndent}writer.Write(true);");
+            GenerateSerialize(
+                source,
+                newIndent,
+                propertyName,
+                shouldTidy,
+                listElementType,
+                listElementRule,
+                listElementRuleArguments
+            );
+            source.AppendLine($"{indent}}}");
+            source.AppendLine($"{indent}else");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{newIndent}writer.Write(false);");
+            source.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            GenerateSerialize(
+                source,
+                indent,
+                propertyName,
+                shouldTidy,
+                listElementType,
+                listElementRule,
+                listElementRuleArguments
+            );
+        }
+    }
+
+    private static void GenerateSerialize(
+        StringBuilder source,
+        string indent,
+        string propertyName,
+        bool shouldTidy,
+        string listElementType,
+        ISerializableMigrationRule listElementRule,
+        string[] listElementRuleArguments
+    )
+    {
         var propertyEntry = $"{propertyName}Entry";
         var propertyCount = $"{propertyName}Count";
 
@@ -163,7 +271,7 @@ public class ListMigrationRule : MigrationRule
         var serializableListElement = new SerializableProperty
         {
             Name = propertyEntry,
-            Type = ruleArguments[argumentsOffset],
+            Type = listElementType,
             Rule = listElementRule.RuleName,
             RuleArguments = listElementRuleArguments
         };

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/ListMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/ListMigrationRule.cs
@@ -126,6 +126,10 @@ public class ListMigrationRule : MigrationRule
                 listElementRuleArguments
             );
             source.AppendLine($"{indent}}}");
+            source.AppendLine($"{indent}else");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{indent}    {propertyName} = default;");
+            source.AppendLine($"{indent}}}");
         }
         else
         {

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/RawSerializableMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/RawSerializableMigrationRule.cs
@@ -99,6 +99,10 @@ public class RawSerializableMigrationRule : MigrationRule
             source.AppendLine($"{indent}{{");
             GenerateDeserialize(source, $"{indent}    ", propertyName, propertyType, parentReference);
             source.AppendLine($"{indent}}}");
+            source.AppendLine($"{indent}else");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{indent}    {propertyName} = default;");
+            source.AppendLine($"{indent}}}");
         }
         else
         {

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/RawSerializableMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/RawSerializableMigrationRule.cs
@@ -97,8 +97,7 @@ public class RawSerializableMigrationRule : MigrationRule
         {
             source.AppendLine($"{indent}if (reader.ReadBool())");
             source.AppendLine($"{indent}{{");
-            var newIndent = $"{indent}    ";
-            GenerateDeserialize(source, newIndent, propertyName, propertyType, parentReference);
+            GenerateDeserialize(source, $"{indent}    ", propertyName, propertyType, parentReference);
             source.AppendLine($"{indent}}}");
         }
         else

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/RawSerializableMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/RawSerializableMigrationRule.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
@@ -48,7 +49,14 @@ public class RawSerializableMigrationRule : MigrationRule
             return false;
         }
 
-        ruleArguments = new[] { requiresParent ? "DeserializationRequiresParent" : "" };
+        var canBeNull = attributes.Any(a => a.IsCanBeNull(compilation));
+        ruleArguments = new string[canBeNull ? 2 : 1];
+        ruleArguments[0] = requiresParent ? "DeserializationRequiresParent" : "";
+        if (canBeNull)
+        {
+            ruleArguments[1] = "@CanBeNull";
+        }
+
         return namedTypeSymbol.IsSerializableRecursive(compilation);
     }
 
@@ -70,11 +78,44 @@ public class RawSerializableMigrationRule : MigrationRule
 
         var propertyType = property.Type;
         var propertyName = property.FieldName ?? property.Name;
+        var canBeNull = false;
 
-        var argument = property.RuleArguments?.Length >= 1 &&
-                       property.RuleArguments[0] == "DeserializationRequiresParent" ? parentReference ?? "" : "";
+        if (property.RuleArguments != null)
+        {
+            if (property.RuleArguments.Length == 0 || property.RuleArguments[0] != "DeserializationRequiresParent")
+            {
+                parentReference = "";
+            }
 
-        source.AppendLine($"{indent}{propertyName} = new {propertyType}({argument});");
+            if (property.RuleArguments.Length >= 1 && property.RuleArguments[property.RuleArguments.Length - 1] == "@CanBeNull")
+            {
+                canBeNull = true;
+            }
+        }
+
+        if (canBeNull)
+        {
+            source.AppendLine($"{indent}if (reader.ReadBool())");
+            source.AppendLine($"{indent}{{");
+            var newIndent = $"{indent}    ";
+            GenerateDeserialize(source, newIndent, propertyName, propertyType, parentReference);
+            source.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            GenerateDeserialize(source, indent, propertyName, propertyType, parentReference);
+        }
+    }
+
+    private static void GenerateDeserialize(
+        StringBuilder source,
+        string indent,
+        string propertyName,
+        string propertyType,
+        string parentReference
+    )
+    {
+        source.AppendLine($"{indent}{propertyName} = new {propertyType}({parentReference});");
         source.AppendLine($"{indent}{propertyName}.Deserialize(reader);");
     }
 
@@ -87,6 +128,25 @@ public class RawSerializableMigrationRule : MigrationRule
             throw new ArgumentException($"Invalid rule applied to property {ruleName}. Expecting {expectedRule}, but received {ruleName}.");
         }
 
-        source.AppendLine($"{indent}{property.FieldName ?? property.Name}.Serialize(writer);");
+        var propertyName = property.FieldName ?? property.Name;
+        bool canBeNull = property.RuleArguments?.Length >= 1 && property.RuleArguments[property.RuleArguments.Length - 1] == "@CanBeNull";
+
+        if (canBeNull)
+        {
+            var newIndent = $"{indent}    ";
+            source.AppendLine($"{indent}if ({propertyName} != default)");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{newIndent}writer.Write(true);");
+            source.AppendLine($"{newIndent}{propertyName}.Serialize(writer);");
+            source.AppendLine($"{indent}}}");
+            source.AppendLine($"{indent}else");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{newIndent}writer.Write(false);");
+            source.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            source.AppendLine($"{indent}{propertyName}.Serialize(writer);");
+        }
     }
 }

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/SerializableInterfaceMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/SerializableInterfaceMigrationRule.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
@@ -34,7 +35,8 @@ public class SerializableInterfaceMigrationRule : MigrationRule
     {
         if (symbol is ITypeSymbol typeSymbol && typeSymbol.HasSerializableInterface(compilation))
         {
-            ruleArguments = Array.Empty<string>();
+            var canBeNull = attributes.Any(a => a.IsCanBeNull(compilation));
+            ruleArguments = canBeNull ? new[] { "@CanBeNull" } : Array.Empty<string>();
             return true;
         }
 
@@ -58,7 +60,21 @@ public class SerializableInterfaceMigrationRule : MigrationRule
             throw new ArgumentException($"Invalid rule applied to property {ruleName}. Expecting {expectedRule}, but received {ruleName}.");
         }
 
-        source.AppendLine($"{indent}{property.FieldName ?? property.Name} = reader.ReadEntity<{property.Type}>();");
+        var propertyType = property.Type;
+        var propertyName = property.FieldName ?? property.Name;
+        var canBeNull = property.RuleArguments?.Length > 0 && property.RuleArguments[0] == "@CanBeNull";
+
+        if (canBeNull)
+        {
+            source.AppendLine($"{indent}if (reader.ReadBool())");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{indent}    {propertyName} = reader.ReadEntity<{propertyType}>();");
+            source.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            source.AppendLine($"{indent}{propertyName} = reader.ReadEntity<{propertyType}>();");
+        }
     }
 
     public override void GenerateSerializationMethod(StringBuilder source, string indent, SerializableProperty property)
@@ -70,6 +86,26 @@ public class SerializableInterfaceMigrationRule : MigrationRule
             throw new ArgumentException($"Invalid rule applied to property {ruleName}. Expecting {expectedRule}, but received {ruleName}.");
         }
 
-        source.AppendLine($"{indent}writer.Write({property.FieldName ?? property.Name});");
+        var propertyType = property.Type;
+        var propertyName = property.FieldName ?? property.Name;
+        var canBeNull = property.RuleArguments?.Length > 0 && property.RuleArguments[0] == "@CanBeNull";
+
+        if (canBeNull)
+        {
+            var newIndent = $"{indent}    ";
+            source.AppendLine($"{indent}if ({propertyName} != default)");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{newIndent}writer.Write(true);");
+            source.AppendLine($"{newIndent}writer.Write({propertyName});");
+            source.AppendLine($"{indent}}}");
+            source.AppendLine($"{indent}else");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{newIndent}writer.Write(false);");
+            source.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            source.AppendLine($"{indent}{propertyName}.Serialize(writer);");
+        }
     }
 }

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/SerializationMethodSignatureMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/SerializationMethodSignatureMigrationRule.cs
@@ -96,8 +96,7 @@ public class SerializationMethodSignatureMigrationRule : MigrationRule
             {
                 source.AppendLine($"{indent}if (reader.ReadBool())");
                 source.AppendLine($"{indent}{{");
-                var newIndent = $"{indent}    ";
-                GenerateDeserialize(source, newIndent, propertyName, propertyType, parentReference);
+                GenerateDeserialize(source, $"{indent}    ", propertyName, propertyType, parentReference);
                 source.AppendLine($"{indent}}}");
             }
             else

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/SerializationMethodSignatureMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/SerializationMethodSignatureMigrationRule.cs
@@ -98,6 +98,10 @@ public class SerializationMethodSignatureMigrationRule : MigrationRule
                 source.AppendLine($"{indent}{{");
                 GenerateDeserialize(source, $"{indent}    ", propertyName, propertyType, parentReference);
                 source.AppendLine($"{indent}}}");
+                source.AppendLine($"{indent}else");
+                source.AppendLine($"{indent}{{");
+                source.AppendLine($"{indent}    {propertyName} = default;");
+                source.AppendLine($"{indent}}}");
             }
             else
             {

--- a/ModernUO.Serialization.Generator/SourceGeneration/SymbolMetadata/SymbolMetadata.UO.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SymbolMetadata/SymbolMetadata.UO.cs
@@ -31,6 +31,7 @@ public static partial class SymbolMetadata
     public const string DELTA_DATE_TIME_ATTRIBUTE = "ModernUO.Serialization.DeltaDateTimeAttribute";
     public const string INTERN_STRING_ATTRIBUTE = "ModernUO.Serialization.InternStringAttribute";
     public const string ENCODED_INT_ATTRIBUTE = "ModernUO.Serialization.EncodedIntAttribute";
+    public const string CAN_BE_NULL_ATTRIBUTE = "ModernUO.Serialization.CanBeNullAttribute";
     public const string TIDY_ATTRIBUTE = "ModernUO.Serialization.TidyAttribute";
     public const string TIMER_DRIFT_ATTRIBUTE = "ModernUO.Serialization.TimerDriftAttribute";
     public const string DESERIALIZE_TIMER_FIELD_ATTRIBUTE = "ModernUO.Serialization.DeserializeTimerFieldAttribute";
@@ -51,6 +52,9 @@ public static partial class SymbolMetadata
     public const string SERIAL_STRUCT = "Server.Serial";
     // ModernUO modified BitArray
     public const string SERVER_BITARRAY_CLASS = "Server.Collections.BitArray";
+
+    public static bool IsCanBeNull(this AttributeData attr, Compilation compilation) =>
+        attr?.IsAttribute(compilation.GetTypeByMetadataName(CAN_BE_NULL_ATTRIBUTE)) == true;
 
     public static bool IsTimerDrift(this AttributeData attr, Compilation compilation) =>
         attr?.IsAttribute(compilation.GetTypeByMetadataName(TIMER_DRIFT_ATTRIBUTE)) == true;

--- a/ModernUO.Serialization.SchemaGenerator/ModernUO.Serialization.SchemaGenerator.csproj
+++ b/ModernUO.Serialization.SchemaGenerator/ModernUO.Serialization.SchemaGenerator.csproj
@@ -5,8 +5,8 @@
         <TargetFramework>net6.0</TargetFramework>
         <LangVersion>preview</LangVersion>
         <OutputType>Exe</OutputType>
-        <AssemblyVersion>2.4.3</AssemblyVersion>
-        <PackageVersion>2.4.3</PackageVersion>
+        <AssemblyVersion>2.5.0</AssemblyVersion>
+        <PackageVersion>2.5.0</PackageVersion>
         <PackAsTool>true</PackAsTool>
         <AssemblyName>ModernUOSchemaGenerator</AssemblyName>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
Adds `[CanBeNull]` for all non-ISerializable reference types. This hints to the generator to prefix serializing the object with a boolean so it knows if it will be null upon deserialization.