### PR TITLE
Fixes bugs, adds support for struct, generics, readonly, more SaveFlag, and SortedSet

### DIFF
--- a/ModernUO.Serialization.Annotations/ModernUO.Serialization.Annotations.csproj
+++ b/ModernUO.Serialization.Annotations/ModernUO.Serialization.Annotations.csproj
@@ -4,8 +4,8 @@
         <PackageId>ModernUO.Serialization.Annotations</PackageId>
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>preview</LangVersion>
-        <AssemblyVersion>2.13.0</AssemblyVersion>
-        <PackageVersion>2.13.0</PackageVersion>
+        <AssemblyVersion>2.14.0</AssemblyVersion>
+        <PackageVersion>2.14.0</PackageVersion>
         <AssemblyName>ModernUO.Serialization.Annotations</AssemblyName>
         <RootNamespace>ModernUO.Serialization</RootNamespace>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/ModernUO.Serialization.Annotations/SerializationGeneratorAttribute.cs
+++ b/ModernUO.Serialization.Annotations/SerializationGeneratorAttribute.cs
@@ -17,7 +17,7 @@ using System;
 
 namespace ModernUO.Serialization;
 
-[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
 public sealed class SerializationGeneratorAttribute : Attribute
 {
     public int Version { get; }

--- a/ModernUO.Serialization.Annotations/SortedSetComparerAttribute.cs
+++ b/ModernUO.Serialization.Annotations/SortedSetComparerAttribute.cs
@@ -1,6 +1,6 @@
 /*************************************************************************
  * ModernUO                                                              *
- * Copyright 2019-2024 - ModernUO Development Team                       *
+ * Copyright 2019-2025 - ModernUO Development Team                       *
  * Email: hi@modernuo.com                                                *
  * File: SortedSetComparerAttribute.cs                                   *
  *                                                                       *

--- a/ModernUO.Serialization.Annotations/SortedSetComparerAttribute.cs
+++ b/ModernUO.Serialization.Annotations/SortedSetComparerAttribute.cs
@@ -1,0 +1,71 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2024 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: SortedSetComparerAttribute.cs                                   *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System;
+
+namespace ModernUO.Serialization;
+
+/// <summary>
+/// Specifies a custom comparer to use when deserializing a SortedSet.
+/// </summary>
+/// <remarks>
+/// Usage examples:
+/// <code>
+/// // Instance comparer - creates new instance: new MyComparer()
+/// [SerializableField(0)]
+/// [SortedSetComparer(typeof(MyComparer))]
+/// private SortedSet&lt;MyType&gt; _items;
+///
+/// // Static member comparer - uses static property: StringComparer.OrdinalIgnoreCase
+/// [SerializableField(0)]
+/// [SortedSetComparer(typeof(StringComparer), nameof(StringComparer.OrdinalIgnoreCase))]
+/// private SortedSet&lt;string&gt; _names;
+/// </code>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+public sealed class SortedSetComparerAttribute : Attribute
+{
+    /// <summary>
+    /// The type that provides the comparer.
+    /// </summary>
+    public Type ComparerType { get; }
+
+    /// <summary>
+    /// Optional static member (property or field) on <see cref="ComparerType"/> that returns the comparer instance.
+    /// If null, a new instance of <see cref="ComparerType"/> will be created.
+    /// </summary>
+    public string? StaticMember { get; }
+
+    /// <summary>
+    /// Creates a SortedSetComparer attribute that instantiates the comparer type.
+    /// </summary>
+    /// <param name="comparerType">The comparer type to instantiate.</param>
+    public SortedSetComparerAttribute(Type comparerType)
+    {
+        ComparerType = comparerType;
+        StaticMember = null;
+    }
+
+    /// <summary>
+    /// Creates a SortedSetComparer attribute that uses a static member from the comparer type.
+    /// </summary>
+    /// <param name="comparerType">The type containing the static member.</param>
+    /// <param name="staticMember">The name of the static property or field.</param>
+    public SortedSetComparerAttribute(Type comparerType, string staticMember)
+    {
+        ComparerType = comparerType;
+        StaticMember = staticMember;
+    }
+}

--- a/ModernUO.Serialization.Generator.Tests/BasicSerializationTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/BasicSerializationTests.cs
@@ -1,0 +1,489 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2024 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: BasicSerializationTests.cs                                      *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using ModernUO.Serialization.Generator.Tests.Helpers;
+using Xunit;
+
+namespace ModernUO.Serialization.Generator.Tests;
+
+public class BasicSerializationTests
+{
+    [Fact]
+    public void SimpleClass_GeneratesSerializationCode()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class SimpleItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("partial class SimpleItem", generatedSource);
+        Assert.Contains("void Serialize(", generatedSource);
+        Assert.Contains("void Deserialize(", generatedSource);
+        Assert.Contains("public string Name", generatedSource); // Generated property
+    }
+
+    [Fact]
+    public void MultipleFields_GeneratesCorrectOrder()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class MultiFieldItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    [SerializableField(1)]
+                    private int _count;
+
+                    [SerializableField(2)]
+                    private bool _active;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("public string Name", generatedSource);
+        Assert.Contains("public int Count", generatedSource);
+        Assert.Contains("public bool Active", generatedSource);
+    }
+
+    [Fact]
+    public void PrimitiveTypes_GeneratesCorrectSerializationMethods()
+    {
+        const string source = """
+            using System;
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class PrimitiveItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private int _intValue;
+
+                    [SerializableField(1)]
+                    private long _longValue;
+
+                    [SerializableField(2)]
+                    private double _doubleValue;
+
+                    [SerializableField(3)]
+                    private DateTime _dateTime;
+
+                    [SerializableField(4)]
+                    private Guid _guid;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("writer.Write(_intValue)", generatedSource);
+        Assert.Contains("writer.Write(_longValue)", generatedSource);
+        Assert.Contains("writer.Write(_doubleValue)", generatedSource);
+        Assert.Contains("reader.ReadInt()", generatedSource);
+        Assert.Contains("reader.ReadLong()", generatedSource);
+        Assert.Contains("reader.ReadDouble()", generatedSource);
+    }
+
+    [Fact]
+    public void SerializableProperty_GeneratesFieldAndProperty()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class PropertyItem : ISerializable
+                {
+                    [SerializableProperty(0)]
+                    public string Name { get; set; }
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        // SerializableProperty should generate a backing field
+        Assert.Contains("_name", generatedSource);
+    }
+
+    [Fact]
+    public void EncodedInt_UsesEncodedMethods()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class EncodedIntItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    [EncodedInt]
+                    private int _encodedValue;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("WriteEncodedInt", generatedSource);
+        Assert.Contains("ReadEncodedInt", generatedSource);
+    }
+
+    [Fact]
+    public void SerialConstructor_GeneratedForISerializable()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class SerialCtorItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        // Should contain a constructor that takes Serial (the constructor is generated)
+        Assert.Contains("SerialCtorItem(", generatedSource);
+        Assert.Contains("Serial", generatedSource);
+    }
+
+    [Fact]
+    public void ListField_GeneratesCollectionSerialization()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class ListItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private List<string> _names;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("WriteEncodedInt", generatedSource); // Collection count
+        Assert.Contains("for", generatedSource.ToLower()); // Loop for serialization
+    }
+
+    [Fact]
+    public void DictionaryField_GeneratesCollectionSerialization()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class DictItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private Dictionary<string, int> _map;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("WriteEncodedInt", generatedSource);
+        Assert.Contains("Dictionary", generatedSource);
+    }
+
+    [Fact]
+    public void HashSetField_GeneratesCollectionSerialization()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class HashSetItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private HashSet<int> _numbers;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("HashSet", generatedSource);
+    }
+
+    [Fact]
+    public void SortedSetField_GeneratesCollectionSerialization()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class SortedSetItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private SortedSet<int> _sortedNumbers;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("SortedSet", generatedSource);
+    }
+
+    [Fact]
+    public void ArrayField_GeneratesArraySerialization()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class ArrayItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private int[] _values;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("int[]", generatedSource);
+    }
+
+    [Fact]
+    public void EnumField_GeneratesEnumSerialization()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                public enum ItemState { Active, Inactive, Pending }
+
+                [SerializationGenerator(0)]
+                public partial class EnumItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private ItemState _state;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("ItemState", generatedSource);
+    }
+
+    [Fact]
+    public void NestedClass_GeneratesCorrectNamespace()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                public partial class OuterClass
+                {
+                    [SerializationGenerator(0)]
+                    public partial class InnerItem : ISerializable
+                    {
+                        [SerializableField(0)]
+                        private string _name;
+
+                        public Serial Serial => default;
+                        public void MarkDirty() { }
+                    }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("partial class OuterClass", generatedSource);
+        Assert.Contains("partial class InnerItem", generatedSource);
+    }
+
+    [Fact]
+    public void VirtualProperty_GeneratesVirtualModifier()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class VirtualItem : ISerializable
+                {
+                    [SerializableField(0, getter: "public", setter: "public", isVirtual: true)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("virtual", generatedSource);
+    }
+
+    [Fact]
+    public void VersionZero_DoesNotIncludeMigrationSwitch()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class VersionZeroItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        // Version 0 should not need migration switch
+        Assert.DoesNotContain("switch (version)", generatedSource);
+    }
+}

--- a/ModernUO.Serialization.Generator.Tests/BasicSerializationTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/BasicSerializationTests.cs
@@ -1,18 +1,3 @@
-/*************************************************************************
- * ModernUO                                                              *
- * Copyright 2019-2024 - ModernUO Development Team                       *
- * Email: hi@modernuo.com                                                *
- * File: BasicSerializationTests.cs                                      *
- *                                                                       *
- * This program is free software: you can redistribute it and/or modify  *
- * it under the terms of the GNU General Public License as published by  *
- * the Free Software Foundation, either version 3 of the License, or     *
- * (at your option) any later version.                                   *
- *                                                                       *
- * You should have received a copy of the GNU General Public License     *
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *************************************************************************/
-
 using ModernUO.Serialization.Generator.Tests.Helpers;
 using Xunit;
 

--- a/ModernUO.Serialization.Generator.Tests/BasicSerializationTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/BasicSerializationTests.cs
@@ -471,4 +471,45 @@ public class BasicSerializationTests
         // Version 0 should not need migration switch
         Assert.DoesNotContain("switch (version)", generatedSource);
     }
+
+    [Fact]
+    public void FieldWithNumber_GeneratesPropertyWithoutSpaces()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class NumberedFieldItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _slayer1;
+
+                    [SerializableField(1)]
+                    private string _slayer2;
+
+                    [SerializableField(2)]
+                    private int _field123;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        // Property names should NOT have spaces (Humanizer 3.x regression)
+        Assert.Contains("public string Slayer1", generatedSource);
+        Assert.Contains("public string Slayer2", generatedSource);
+        Assert.Contains("public int Field123", generatedSource);
+        // Ensure no spaces in property names
+        Assert.DoesNotContain("Slayer 1", generatedSource);
+        Assert.DoesNotContain("Slayer 2", generatedSource);
+        Assert.DoesNotContain("Field 123", generatedSource);
+    }
 }

--- a/ModernUO.Serialization.Generator.Tests/DiagnosticTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/DiagnosticTests.cs
@@ -1,18 +1,3 @@
-/*************************************************************************
- * ModernUO                                                              *
- * Copyright 2019-2024 - ModernUO Development Team                       *
- * Email: hi@modernuo.com                                                *
- * File: DiagnosticTests.cs                                              *
- *                                                                       *
- * This program is free software: you can redistribute it and/or modify  *
- * it under the terms of the GNU General Public License as published by  *
- * the Free Software Foundation, either version 3 of the License, or     *
- * (at your option) any later version.                                   *
- *                                                                       *
- * You should have received a copy of the GNU General Public License     *
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *************************************************************************/
-
 using ModernUO.Serialization.Generator.Tests.Helpers;
 using Xunit;
 

--- a/ModernUO.Serialization.Generator.Tests/DiagnosticTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/DiagnosticTests.cs
@@ -1,0 +1,305 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2024 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: DiagnosticTests.cs                                              *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using ModernUO.Serialization.Generator.Tests.Helpers;
+using Xunit;
+
+namespace ModernUO.Serialization.Generator.Tests;
+
+public class DiagnosticTests
+{
+    [Fact]
+    public void SG3001_NonPartialClass_ReportsDiagnostic()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public class NonPartialItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void Serialize(IGenericWriter writer) { }
+                    public void Deserialize(IGenericReader reader) { }
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, _) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "SG3001");
+    }
+
+    [Fact]
+    public void SG3003_DuplicateFieldOrder_ReportsDiagnostic()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class DuplicateOrderItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    [SerializableField(0)]
+                    private int _count;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, _) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "SG3003");
+    }
+
+    [Fact]
+    public void SG3004_InvalidUseField_ReportsDiagnostic()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class InvalidFieldItem : ISerializable
+                {
+                    [SerializableProperty(0, useField: "_nonExistentField")]
+                    public string Name { get; set; }
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, _) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "SG3004");
+    }
+
+    [Fact]
+    public void SG3005_NonSequentialOrder_ReportsDiagnostic()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class GapOrderItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    [SerializableField(2)]
+                    private int _count;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, _) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "SG3005");
+    }
+
+    [Fact]
+    public void SG3006_NegativeOrder_ReportsDiagnostic()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class NegativeOrderItem : ISerializable
+                {
+                    [SerializableField(-1)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, _) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "SG3006");
+    }
+
+    [Fact]
+    public void SG3007_UnsupportedType_ReportsDiagnostic()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                public class UnsupportedType { }
+
+                [SerializationGenerator(0)]
+                public partial class UnsupportedItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private UnsupportedType _unsupported;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, _) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "SG3007");
+    }
+
+    [Fact]
+    public void SG3009_StructWithoutDeserialize_ReportsDiagnostic()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial struct MissingDeserializeStruct
+                {
+                    [SerializableField(0)]
+                    private int _value;
+                }
+            }
+            """;
+
+        var (diagnostics, _) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "SG3009");
+    }
+
+    [Fact]
+    public void ValidClass_NoDiagnostics()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class ValidItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    [SerializableField(1)]
+                    private int _count;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+    }
+
+    [Fact]
+    public void DuplicateSaveFlagOrder_ReportsDiagnostic()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class DuplicateFlagItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    [SerializableField(1)]
+                    private int _count;
+
+                    [SerializableFieldSaveFlag(0)]
+                    private bool ShouldSerializeName() => _name != null;
+
+                    [SerializableFieldSaveFlag(0)]
+                    private bool ShouldSerializeName2() => _name != null;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, _) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "SG3003");
+    }
+
+    [Fact]
+    public void NegativeSaveFlagOrder_ReportsDiagnostic()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class NegativeFlagItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    [SerializableFieldSaveFlag(-1)]
+                    private bool ShouldSerializeName() => _name != null;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, _) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "SG3006");
+    }
+}

--- a/ModernUO.Serialization.Generator.Tests/GenericSerializationTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/GenericSerializationTests.cs
@@ -1,18 +1,3 @@
-/*************************************************************************
- * ModernUO                                                              *
- * Copyright 2019-2024 - ModernUO Development Team                       *
- * Email: hi@modernuo.com                                                *
- * File: GenericSerializationTests.cs                                    *
- *                                                                       *
- * This program is free software: you can redistribute it and/or modify  *
- * it under the terms of the GNU General Public License as published by  *
- * the Free Software Foundation, either version 3 of the License, or     *
- * (at your option) any later version.                                   *
- *                                                                       *
- * You should have received a copy of the GNU General Public License     *
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *************************************************************************/
-
 using ModernUO.Serialization.Generator.Tests.Helpers;
 using Xunit;
 

--- a/ModernUO.Serialization.Generator.Tests/GenericSerializationTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/GenericSerializationTests.cs
@@ -1,0 +1,202 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2024 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: GenericSerializationTests.cs                                    *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using ModernUO.Serialization.Generator.Tests.Helpers;
+using Xunit;
+
+namespace ModernUO.Serialization.Generator.Tests;
+
+public class GenericSerializationTests
+{
+    [Fact]
+    public void GenericClass_SingleTypeParameter_GeneratesCorrectly()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class GenericItem<T> : ISerializable where T : struct
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("partial class GenericItem<T>", generatedSource);
+        Assert.Contains("where T : struct", generatedSource);
+    }
+
+    [Fact]
+    public void GenericClass_MultipleTypeParameters_GeneratesCorrectly()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class GenericItem<TKey, TValue> : ISerializable
+                    where TKey : class
+                    where TValue : struct
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("partial class GenericItem<TKey, TValue>", generatedSource);
+        Assert.Contains("where TKey : class", generatedSource);
+        Assert.Contains("where TValue : struct", generatedSource);
+    }
+
+    [Fact]
+    public void GenericClass_ConstraintWithNew_GeneratesCorrectly()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class GenericItem<T> : ISerializable where T : class, new()
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("where T : class, new()", generatedSource);
+    }
+
+    [Fact]
+    public void GenericClass_NoConstraints_GeneratesCorrectly()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class GenericItem<T> : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("partial class GenericItem<T>", generatedSource);
+        // Should not have where clause
+        Assert.DoesNotContain("where T :", generatedSource);
+    }
+
+    [Fact]
+    public void GenericClass_NestedInGenericClass_GeneratesCorrectly()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                public partial class OuterGeneric<TOuter>
+                {
+                    [SerializationGenerator(0)]
+                    public partial class InnerItem : ISerializable
+                    {
+                        [SerializableField(0)]
+                        private string _name;
+
+                        public Serial Serial => default;
+                        public void MarkDirty() { }
+                    }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("partial class OuterGeneric<TOuter>", generatedSource);
+        Assert.Contains("partial class InnerItem", generatedSource);
+    }
+
+    [Fact]
+    public void GenericClass_InterfaceConstraint_GeneratesCorrectly()
+    {
+        const string source = """
+            using System;
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class GenericItem<T> : ISerializable where T : IComparable<T>
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("where T : System.IComparable<T>", generatedSource);
+    }
+}

--- a/ModernUO.Serialization.Generator.Tests/Helpers/SourceGeneratorTestHelper.cs
+++ b/ModernUO.Serialization.Generator.Tests/Helpers/SourceGeneratorTestHelper.cs
@@ -1,0 +1,255 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2024 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: SourceGeneratorTestHelper.cs                                    *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using ModernUO.Serialization.Generator;
+
+namespace ModernUO.Serialization.Generator.Tests.Helpers;
+
+public static class SourceGeneratorTestHelper
+{
+    // Stub code for Server interfaces needed by the generator
+    public const string ServerStubs = """
+        namespace Server
+        {
+            public interface IGenericReader
+            {
+                string ReadString();
+                int ReadInt();
+                uint ReadUInt();
+                long ReadLong();
+                ulong ReadULong();
+                short ReadShort();
+                ushort ReadUShort();
+                byte ReadByte();
+                sbyte ReadSByte();
+                bool ReadBool();
+                float ReadFloat();
+                double ReadDouble();
+                decimal ReadDecimal();
+                System.DateTime ReadDateTime();
+                System.DateTime ReadDeltaTime();
+                System.TimeSpan ReadTimeSpan();
+                System.Guid ReadGuid();
+                int ReadEncodedInt();
+                T ReadEnum<T>() where T : struct, System.Enum;
+                Serial ReadSerial();
+                Point2D ReadPoint2D();
+                Point3D ReadPoint3D();
+                Rectangle2D ReadRectangle2D();
+                Rectangle3D ReadRectangle3D();
+            }
+
+            public interface IGenericWriter
+            {
+                void Write(string value);
+                void Write(int value);
+                void Write(uint value);
+                void Write(long value);
+                void Write(ulong value);
+                void Write(short value);
+                void Write(ushort value);
+                void Write(byte value);
+                void Write(sbyte value);
+                void Write(bool value);
+                void Write(float value);
+                void Write(double value);
+                void Write(decimal value);
+                void Write(System.DateTime value);
+                void WriteDeltaTime(System.DateTime value);
+                void Write(System.TimeSpan value);
+                void Write(System.Guid value);
+                void WriteEncodedInt(int value);
+                void Write<T>(T value) where T : struct, System.Enum;
+                void Write(Serial value);
+                void Write(Point2D value);
+                void Write(Point3D value);
+                void Write(Rectangle2D value);
+                void Write(Rectangle3D value);
+            }
+
+            public interface ISerializable
+            {
+                Serial Serial { get; }
+                void Serialize(IGenericWriter writer);
+                void Deserialize(IGenericReader reader);
+                void MarkDirty();
+            }
+
+            public static class ISerializableExtensions
+            {
+                public static void MarkDirty(ISerializable entity) { }
+            }
+
+            public readonly struct Serial
+            {
+                public readonly uint Value;
+                public Serial(uint value) => Value = value;
+            }
+
+            public struct Point2D
+            {
+                public int X, Y;
+            }
+
+            public struct Point3D
+            {
+                public int X, Y, Z;
+            }
+
+            public struct Rectangle2D
+            {
+                public Point2D Start, End;
+            }
+
+            public struct Rectangle3D
+            {
+                public Point3D Start, End;
+            }
+
+            public class TextDefinition
+            {
+                public int Number { get; set; }
+                public string String { get; set; }
+            }
+
+            public class Poison
+            {
+                public int Level { get; set; }
+            }
+
+            public class Race
+            {
+                public int Id { get; set; }
+            }
+
+            public class Map
+            {
+                public int Id { get; set; }
+            }
+
+            public class Timer
+            {
+                public System.TimeSpan Delay { get; set; }
+            }
+        }
+        """;
+
+    public static (ImmutableArray<Diagnostic> Diagnostics, string? GeneratedSource) RunGenerator(
+        string sourceCode,
+        string[]? additionalSources = null,
+        IEnumerable<(string fileName, string content)>? additionalTexts = null)
+    {
+        var syntaxTrees = new List<SyntaxTree>
+        {
+            CSharpSyntaxTree.ParseText(sourceCode),
+            CSharpSyntaxTree.ParseText(ServerStubs)
+        };
+
+        if (additionalSources != null)
+        {
+            foreach (var additional in additionalSources)
+            {
+                syntaxTrees.Add(CSharpSyntaxTree.ParseText(additional));
+            }
+        }
+
+        // Get all the runtime references needed for compilation
+        var trustedAssemblies = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator);
+
+        var references = trustedAssemblies
+            .Where(p => !string.IsNullOrEmpty(p))
+            .Select(p => MetadataReference.CreateFromFile(p))
+            .Cast<MetadataReference>()
+            .Concat([MetadataReference.CreateFromFile(typeof(SerializationGeneratorAttribute).Assembly.Location)])
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            syntaxTrees,
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        var generator = new EntitySerializationGenerator();
+
+        var additionalTextsList = new List<AdditionalText>();
+        if (additionalTexts != null)
+        {
+            foreach (var (fileName, content) in additionalTexts)
+            {
+                additionalTextsList.Add(new InMemoryAdditionalText(fileName, content));
+            }
+        }
+
+        var driver = CSharpGeneratorDriver.Create(generator)
+            .AddAdditionalTexts(ImmutableArray.CreateRange(additionalTextsList));
+
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+        var generatedSource = outputCompilation.SyntaxTrees
+            .FirstOrDefault(st => st.FilePath.EndsWith(".Serialization.g.cs"))
+            ?.GetText()
+            .ToString();
+
+        return (diagnostics, generatedSource);
+    }
+
+    public static bool HasDiagnostic(ImmutableArray<Diagnostic> diagnostics, string diagnosticId)
+    {
+        return diagnostics.Any(d => d.Id == diagnosticId);
+    }
+
+    public static Diagnostic? GetDiagnostic(ImmutableArray<Diagnostic> diagnostics, string diagnosticId)
+    {
+        return diagnostics.FirstOrDefault(d => d.Id == diagnosticId);
+    }
+
+    public static bool GeneratedSourceContains(string? generatedSource, string text)
+    {
+        return generatedSource?.Contains(text) ?? false;
+    }
+
+    public static bool GeneratedSourceContainsAll(string? generatedSource, params string[] texts)
+    {
+        if (generatedSource == null) return false;
+        return texts.All(t => generatedSource.Contains(t));
+    }
+}
+
+public class InMemoryAdditionalText : AdditionalText
+{
+    private readonly string _path;
+    private readonly string _content;
+
+    public InMemoryAdditionalText(string path, string content)
+    {
+        _path = path;
+        _content = content;
+    }
+
+    public override string Path => _path;
+
+    public override SourceText? GetText(CancellationToken cancellationToken = default)
+    {
+        return SourceText.From(_content, Encoding.UTF8);
+    }
+}

--- a/ModernUO.Serialization.Generator.Tests/Helpers/SourceGeneratorTestHelper.cs
+++ b/ModernUO.Serialization.Generator.Tests/Helpers/SourceGeneratorTestHelper.cs
@@ -1,18 +1,3 @@
-/*************************************************************************
- * ModernUO                                                              *
- * Copyright 2019-2024 - ModernUO Development Team                       *
- * Email: hi@modernuo.com                                                *
- * File: SourceGeneratorTestHelper.cs                                    *
- *                                                                       *
- * This program is free software: you can redistribute it and/or modify  *
- * it under the terms of the GNU General Public License as published by  *
- * the Free Software Foundation, either version 3 of the License, or     *
- * (at your option) any later version.                                   *
- *                                                                       *
- * You should have received a copy of the GNU General Public License     *
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *************************************************************************/
-
 using System.Collections.Immutable;
 using System.Reflection;
 using System.Text;

--- a/ModernUO.Serialization.Generator.Tests/MigrationTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/MigrationTests.cs
@@ -64,7 +64,7 @@ public class MigrationTests
             }
             """;
 
-        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(
+        var (_, generatedSource) = SourceGeneratorTestHelper.RunGenerator(
             source,
             additionalTexts: [("TestNamespace.MigratingItem.v0.json", migrationJson)]
         );

--- a/ModernUO.Serialization.Generator.Tests/MigrationTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/MigrationTests.cs
@@ -1,0 +1,263 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2024 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: MigrationTests.cs                                               *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using ModernUO.Serialization.Generator.Tests.Helpers;
+using Xunit;
+
+namespace ModernUO.Serialization.Generator.Tests;
+
+public class MigrationTests
+{
+    [Fact]
+    public void Version1_WithMigrationFile_GeneratesMigrationCode()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(1)]
+                public partial class MigratingItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    [SerializableField(1)]
+                    private int _newField;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+
+                    private void MigrateFrom(V0Content content)
+                    {
+                        _name = content.Name;
+                        _newField = 0;
+                    }
+                }
+            }
+            """;
+
+        const string migrationJson = """
+            {
+                "version": 0,
+                "type": "TestNamespace.MigratingItem",
+                "properties": [
+                    {
+                        "name": "Name",
+                        "type": "string",
+                        "rule": "PrimitiveTypeMigrationRule"
+                    }
+                ]
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(
+            source,
+            additionalTexts: [("TestNamespace.MigratingItem.v0.json", migrationJson)]
+        );
+
+        // With migrations, there may be diagnostics about missing MigrateFrom method
+        // Just verify that the generator ran and produced output
+        Assert.NotNull(generatedSource);
+        // Should generate V0Content struct when migration file is present
+        Assert.Contains("V0Content", generatedSource);
+    }
+
+    [Fact]
+    public void MigrationFileRegex_MatchesStandardFormat()
+    {
+        var regex = ModernUO.Serialization.Generator.SerializableMigrationSchema.MigrationFileRegex;
+
+        Assert.True(regex.IsMatch("MyClass.v0.json"));
+        Assert.True(regex.IsMatch("MyClass.v1.json"));
+        Assert.True(regex.IsMatch("MyClass.V0.json"));
+        Assert.True(regex.IsMatch("Namespace.MyClass.v0.json"));
+        Assert.True(regex.IsMatch("Deep.Namespace.MyClass.v0.json"));
+    }
+
+    [Fact]
+    public void MigrationFileRegex_MatchesGenericFormat()
+    {
+        var regex = ModernUO.Serialization.Generator.SerializableMigrationSchema.MigrationFileRegex;
+
+        Assert.True(regex.IsMatch("MyClass`1.v0.json"));
+        Assert.True(regex.IsMatch("MyClass`2.v0.json"));
+        Assert.True(regex.IsMatch("Namespace.MyClass`1.v0.json"));
+        Assert.True(regex.IsMatch("Deep.Namespace.MyClass`2.v1.json"));
+    }
+
+    [Fact]
+    public void MigrationFileRegex_DoesNotMatchInvalid()
+    {
+        var regex = ModernUO.Serialization.Generator.SerializableMigrationSchema.MigrationFileRegex;
+
+        Assert.False(regex.IsMatch("MyClass.json"));
+        Assert.False(regex.IsMatch("MyClass.v.json"));
+        Assert.False(regex.IsMatch("MyClass.va.json"));
+        Assert.False(regex.IsMatch(".v0.json"));
+    }
+
+    [Fact]
+    public void MatchMigrationFilename_ExtractsCorrectInfo()
+    {
+        Assert.True(ModernUO.Serialization.Generator.SerializableMigrationSchema.MatchMigrationFilename(
+            "MyClass.v0.json", out var className, out var version));
+        Assert.Equal("MyClass", className);
+        Assert.Equal(0, version);
+
+        Assert.True(ModernUO.Serialization.Generator.SerializableMigrationSchema.MatchMigrationFilename(
+            "Namespace.MyClass.v5.json", out className, out version));
+        Assert.Equal("Namespace.MyClass", className);
+        Assert.Equal(5, version);
+    }
+
+    [Fact]
+    public void MatchMigrationFilename_ExtractsGenericInfo()
+    {
+        Assert.True(ModernUO.Serialization.Generator.SerializableMigrationSchema.MatchMigrationFilename(
+            "MyClass`1.v0.json", out var className, out var version));
+        Assert.Equal("MyClass`1", className);
+        Assert.Equal(0, version);
+
+        Assert.True(ModernUO.Serialization.Generator.SerializableMigrationSchema.MatchMigrationFilename(
+            "Namespace.MyClass`2.v3.json", out className, out version));
+        Assert.Equal("Namespace.MyClass`2", className);
+        Assert.Equal(3, version);
+    }
+
+    [Fact]
+    public void MultipleMigrations_GeneratesAllVersionContent()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(2)]
+                public partial class MultiMigrateItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    [SerializableField(1)]
+                    private int _count;
+
+                    [SerializableField(2)]
+                    private bool _active;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+
+                    private void MigrateFrom(V0Content content) { }
+                    private void MigrateFrom(V1Content content) { }
+                }
+            }
+            """;
+
+        const string migrationV0 = """
+            {
+                "version": 0,
+                "type": "TestNamespace.MultiMigrateItem",
+                "properties": [
+                    { "name": "Name", "type": "string", "rule": "PrimitiveTypeMigrationRule" }
+                ]
+            }
+            """;
+
+        const string migrationV1 = """
+            {
+                "version": 1,
+                "type": "TestNamespace.MultiMigrateItem",
+                "properties": [
+                    { "name": "Name", "type": "string", "rule": "PrimitiveTypeMigrationRule" },
+                    { "name": "Count", "type": "int", "rule": "PrimitiveTypeMigrationRule" }
+                ]
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(
+            source,
+            additionalTexts: [
+                ("TestNamespace.MultiMigrateItem.v0.json", migrationV0),
+                ("TestNamespace.MultiMigrateItem.v1.json", migrationV1)
+            ]
+        );
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("V0Content", generatedSource);
+        Assert.Contains("V1Content", generatedSource);
+    }
+
+    [Fact]
+    public void EncodedVersion_UsesEncodedIntForVersion()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0, encodedVersion: true)]
+                public partial class EncodedVersionItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("WriteEncodedInt(SerializationVersion)", generatedSource);
+        Assert.Contains("ReadEncodedInt()", generatedSource);
+    }
+
+    [Fact]
+    public void NonEncodedVersion_UsesIntForVersion()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0, encodedVersion: false)]
+                public partial class NonEncodedVersionItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("Write(SerializationVersion)", generatedSource);
+        Assert.Contains("ReadInt()", generatedSource);
+    }
+}

--- a/ModernUO.Serialization.Generator.Tests/MigrationTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/MigrationTests.cs
@@ -1,18 +1,3 @@
-/*************************************************************************
- * ModernUO                                                              *
- * Copyright 2019-2024 - ModernUO Development Team                       *
- * Email: hi@modernuo.com                                                *
- * File: MigrationTests.cs                                               *
- *                                                                       *
- * This program is free software: you can redistribute it and/or modify  *
- * it under the terms of the GNU General Public License as published by  *
- * the Free Software Foundation, either version 3 of the License, or     *
- * (at your option) any later version.                                   *
- *                                                                       *
- * You should have received a copy of the GNU General Public License     *
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *************************************************************************/
-
 using ModernUO.Serialization.Generator.Tests.Helpers;
 using Xunit;
 

--- a/ModernUO.Serialization.Generator.Tests/ModernUO.Serialization.Generator.Tests.csproj
+++ b/ModernUO.Serialization.Generator.Tests/ModernUO.Serialization.Generator.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>preview</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\ModernUO.Serialization.Generator\ModernUO.Serialization.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
+        <ProjectReference Include="..\ModernUO.Serialization.Annotations\ModernUO.Serialization.Annotations.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/ModernUO.Serialization.Generator.Tests/ModernUO.Serialization.Generator.Tests.csproj
+++ b/ModernUO.Serialization.Generator.Tests/ModernUO.Serialization.Generator.Tests.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/ModernUO.Serialization.Generator.Tests/ReadonlyFieldTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/ReadonlyFieldTests.cs
@@ -1,0 +1,280 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2024 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: ReadonlyFieldTests.cs                                           *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using ModernUO.Serialization.Generator.Tests.Helpers;
+using Xunit;
+
+namespace ModernUO.Serialization.Generator.Tests;
+
+public class ReadonlyFieldTests
+{
+    [Fact]
+    public void ReadonlyField_GeneratesGetterOnlyProperty()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class ReadonlyItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private readonly string _id;
+
+                    [SerializableField(1)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+
+        // Readonly field should have a getter-only property (no setter)
+        Assert.Contains("public string Id", generatedSource);
+        Assert.Contains("get =>", generatedSource);
+
+        // Non-readonly field should have normal property with setter
+        Assert.Contains("public string Name", generatedSource);
+        Assert.Contains("set", generatedSource);
+
+        // Verify Id has no setter (appears before Name in the source)
+        var idIndex = generatedSource.IndexOf("public string Id");
+        var nameIndex = generatedSource.IndexOf("public string Name");
+        var setterAfterIdIndex = generatedSource.IndexOf("set", idIndex);
+        // If there's a setter after Id, it should be after Name's definition (i.e., it's Name's setter, not Id's)
+        Assert.True(idIndex < nameIndex, "Id property should appear before Name property");
+        Assert.True(setterAfterIdIndex < 0 || setterAfterIdIndex > nameIndex, "Id should not have a setter");
+    }
+
+    [Fact]
+    public void ReadonlyField_NotSerializedOrDeserialized()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class ReadonlyItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private readonly string _id;
+
+                    [SerializableField(1)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+
+        // Count occurrences of write/read for name (should exist) but not for id in serialization
+        // The readonly _id field should not be written in Serialize
+        var serializeMethod = ExtractMethod(generatedSource, "void Serialize");
+        Assert.NotNull(serializeMethod);
+        Assert.DoesNotContain("_id", serializeMethod);
+        Assert.Contains("_name", serializeMethod);
+
+        // The readonly _id field should not be read in Deserialize
+        var deserializeMethod = ExtractMethod(generatedSource, "void Deserialize");
+        Assert.NotNull(deserializeMethod);
+        Assert.DoesNotContain("_id", deserializeMethod);
+        Assert.Contains("_name", deserializeMethod);
+    }
+
+    [Fact]
+    public void ReadonlyField_MixedWithNonReadonly_CorrectOrder()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class MixedItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _first;
+
+                    [SerializableField(1)]
+                    private readonly string _readonlyMiddle;
+
+                    [SerializableField(2)]
+                    private string _last;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+
+        // All properties should be generated
+        Assert.Contains("public string First", generatedSource);
+        Assert.Contains("public string ReadonlyMiddle", generatedSource);
+        Assert.Contains("public string Last", generatedSource);
+
+        // Only non-readonly fields in serialization
+        var serializeMethod = ExtractMethod(generatedSource, "void Serialize");
+        Assert.Contains("_first", serializeMethod);
+        Assert.DoesNotContain("_readonlyMiddle", serializeMethod);
+        Assert.Contains("_last", serializeMethod);
+    }
+
+    [Fact]
+    public void ReadonlyField_WithSaveFlag_FlagExcluded()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class ReadonlyFlagItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private readonly string _id;
+
+                    [SerializableField(1)]
+                    private string _name;
+
+                    [SerializableFieldSaveFlag(0)]
+                    private bool ShouldSerializeId() => _id != null;
+
+                    [SerializableFieldSaveFlag(1)]
+                    private bool ShouldSerializeName() => _name != null;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+
+        // Only Name should be in the SaveFlag enum, not Id
+        Assert.Contains("enum SaveFlag", generatedSource);
+        Assert.Contains("Name", generatedSource);
+        // The Id should not be in the save flags since it's readonly
+        var enumDef = ExtractEnum(generatedSource, "SaveFlag");
+        Assert.DoesNotContain("Id", enumDef);
+    }
+
+    [Fact]
+    public void AllReadonlyFields_NoSerializationGenerated()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class AllReadonlyItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private readonly string _id;
+
+                    [SerializableField(1)]
+                    private readonly int _version;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+
+        // Properties should still be generated (readonly fields get get-only properties)
+        Assert.Contains("public string Id", generatedSource);
+        Assert.Contains("public int Version", generatedSource);
+        // These are get-only properties
+        Assert.Contains("get =>", generatedSource);
+
+        // Serialize/Deserialize should be mostly empty (just version handling)
+        var serializeMethod = ExtractMethod(generatedSource, "void Serialize");
+        Assert.DoesNotContain("_id", serializeMethod);
+        Assert.DoesNotContain("_version", serializeMethod);
+    }
+
+    private static string? ExtractMethod(string source, string methodSignature)
+    {
+        var startIndex = source.IndexOf(methodSignature);
+        if (startIndex < 0) return null;
+
+        int braceCount = 0;
+        int bodyStart = source.IndexOf('{', startIndex);
+        if (bodyStart < 0) return null;
+
+        int i = bodyStart;
+        do
+        {
+            if (source[i] == '{') braceCount++;
+            else if (source[i] == '}') braceCount--;
+            i++;
+        } while (braceCount > 0 && i < source.Length);
+
+        return source.Substring(startIndex, i - startIndex);
+    }
+
+    private static string? ExtractEnum(string source, string enumName)
+    {
+        var pattern = $"enum {enumName}";
+        var startIndex = source.IndexOf(pattern);
+        if (startIndex < 0) return null;
+
+        int braceCount = 0;
+        int bodyStart = source.IndexOf('{', startIndex);
+        if (bodyStart < 0) return null;
+
+        int i = bodyStart;
+        do
+        {
+            if (source[i] == '{') braceCount++;
+            else if (source[i] == '}') braceCount--;
+            i++;
+        } while (braceCount > 0 && i < source.Length);
+
+        return source.Substring(startIndex, i - startIndex);
+    }
+}

--- a/ModernUO.Serialization.Generator.Tests/ReadonlyFieldTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/ReadonlyFieldTests.cs
@@ -1,18 +1,3 @@
-/*************************************************************************
- * ModernUO                                                              *
- * Copyright 2019-2024 - ModernUO Development Team                       *
- * Email: hi@modernuo.com                                                *
- * File: ReadonlyFieldTests.cs                                           *
- *                                                                       *
- * This program is free software: you can redistribute it and/or modify  *
- * it under the terms of the GNU General Public License as published by  *
- * the Free Software Foundation, either version 3 of the License, or     *
- * (at your option) any later version.                                   *
- *                                                                       *
- * You should have received a copy of the GNU General Public License     *
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *************************************************************************/
-
 using ModernUO.Serialization.Generator.Tests.Helpers;
 using Xunit;
 

--- a/ModernUO.Serialization.Generator.Tests/SaveFlagTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/SaveFlagTests.cs
@@ -1,18 +1,3 @@
-/*************************************************************************
- * ModernUO                                                              *
- * Copyright 2019-2024 - ModernUO Development Team                       *
- * Email: hi@modernuo.com                                                *
- * File: SaveFlagTests.cs                                                *
- *                                                                       *
- * This program is free software: you can redistribute it and/or modify  *
- * it under the terms of the GNU General Public License as published by  *
- * the Free Software Foundation, either version 3 of the License, or     *
- * (at your option) any later version.                                   *
- *                                                                       *
- * You should have received a copy of the GNU General Public License     *
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *************************************************************************/
-
 using System.Text;
 using System.Text.RegularExpressions;
 using ModernUO.Serialization.Generator.Tests.Helpers;

--- a/ModernUO.Serialization.Generator.Tests/SaveFlagTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/SaveFlagTests.cs
@@ -180,13 +180,33 @@ public partial class SaveFlagTests
 
         Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
         Assert.NotNull(generatedSource);
-        // Should have SaveFlag enum with ulong type (for > 32 flags, uses ulong up to 64)
-        // When > 64 flags, should generate multiple enums
-        Assert.Contains("enum SaveFlag", generatedSource);
-        // For 70 flags, need 2 enums (64 + 6)
-        // Check that there are multiple SaveFlag usages (SaveFlag and SaveFlag2 or multiple ulong enums)
-        var saveFlagCount = EnumSaveFlagRegex().Count(generatedSource);
-        Assert.True(saveFlagCount >= 2, $"Expected at least 2 SaveFlag enums, found {saveFlagCount}");
+
+        // Should have SaveFlag enum (first 64 flags)
+        Assert.Matches(EnumSaveFlagRegex(), generatedSource);
+
+        // Should have SaveFlag2 enum (flags 65-70)
+        Assert.Matches(EnumSaveFlag2Regex(), generatedSource);
+
+        // Verify correct enum naming - should NOT have duplicate "enum SaveFlag : ulong" without number
+        var saveFlagMatches = EnumSaveFlagRegex().Matches(generatedSource);
+        var saveFlag2Matches = EnumSaveFlag2Regex().Matches(generatedSource);
+        Assert.Single(saveFlagMatches); // Only one "enum SaveFlag : ulong"
+        Assert.Single(saveFlag2Matches); // Only one "enum SaveFlag2 : ulong"
+
+        // Verify serialization uses correct enum for fields >= 64
+        // Field64 should use saveFlags2 & SaveFlag2.Field64
+        Assert.Matches(SerializeSaveFlags2Regex(), generatedSource);
+
+        // Verify deserialization uses correct enum for fields >= 64
+        Assert.Matches(DeserializeSaveFlags2Regex(), generatedSource);
+
+        // Verify fields 0-63 use SaveFlag (not SaveFlag2)
+        Assert.Contains("saveFlags & SaveFlag.Field0", generatedSource);
+        Assert.Contains("saveFlags & SaveFlag.Field63", generatedSource);
+
+        // Verify fields 64+ use SaveFlag2
+        Assert.Contains("saveFlags2 & SaveFlag2.Field64", generatedSource);
+        Assert.Contains("saveFlags2 & SaveFlag2.Field69", generatedSource);
     }
 
     [Fact]
@@ -224,6 +244,15 @@ public partial class SaveFlagTests
         Assert.Contains("GetCountDefault", generatedSource);
     }
 
-    [GeneratedRegex("enum SaveFlag")]
+    [GeneratedRegex(@"enum SaveFlag\s*:\s*ulong")]
     private static partial Regex EnumSaveFlagRegex();
+
+    [GeneratedRegex(@"enum SaveFlag2\s*:\s*ulong")]
+    private static partial Regex EnumSaveFlag2Regex();
+
+    [GeneratedRegex(@"saveFlags2\s*&\s*SaveFlag2\.Field")]
+    private static partial Regex SerializeSaveFlags2Regex();
+
+    [GeneratedRegex(@"saveFlags2\s*&\s*SaveFlag2\.Field")]
+    private static partial Regex DeserializeSaveFlags2Regex();
 }

--- a/ModernUO.Serialization.Generator.Tests/SaveFlagTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/SaveFlagTests.cs
@@ -1,0 +1,229 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2024 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: SaveFlagTests.cs                                                *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System.Text;
+using System.Text.RegularExpressions;
+using ModernUO.Serialization.Generator.Tests.Helpers;
+using Xunit;
+
+namespace ModernUO.Serialization.Generator.Tests;
+
+public partial class SaveFlagTests
+{
+    [Fact]
+    public void SingleSaveFlag_GeneratesEnum()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class SaveFlagItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    [SerializableFieldSaveFlag(0)]
+                    private bool ShouldSerializeName() => _name != null;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("enum SaveFlag", generatedSource);
+        Assert.Contains("None", generatedSource);
+        Assert.Contains("Name", generatedSource);
+    }
+
+    [Fact]
+    public void MultipleSaveFlags_Under32_UsesInt()
+    {
+        // Generate source with 5 fields, all with save flags
+        var sb = new StringBuilder();
+        sb.AppendLine("""
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class MultiFlagItem : ISerializable
+                {
+            """);
+
+        for (int i = 0; i < 5; i++)
+        {
+            sb.AppendLine($"        [SerializableField({i})]");
+            sb.AppendLine($"        private string _field{i};");
+            sb.AppendLine();
+            sb.AppendLine($"        [SerializableFieldSaveFlag({i})]");
+            sb.AppendLine($"        private bool ShouldSerializeField{i}() => _field{i} != null;");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("""
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """);
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(sb.ToString());
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("enum SaveFlag", generatedSource);
+        // Should not have : ulong
+        Assert.DoesNotContain(": ulong", generatedSource);
+        // Should have all 5 field flags
+        for (int i = 0; i < 5; i++)
+        {
+            Assert.Contains($"Field{i}", generatedSource);
+        }
+    }
+
+    [Fact]
+    public void SaveFlags_Over32_UsesUlong()
+    {
+        // Generate source with 35 fields, all with save flags
+        var sb = new StringBuilder();
+        sb.AppendLine("""
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class ManyFlagItem : ISerializable
+                {
+            """);
+
+        for (int i = 0; i < 35; i++)
+        {
+            sb.AppendLine($"        [SerializableField({i})]");
+            sb.AppendLine($"        private int _field{i};");
+            sb.AppendLine();
+            sb.AppendLine($"        [SerializableFieldSaveFlag({i})]");
+            sb.AppendLine($"        private bool ShouldSerializeField{i}() => _field{i} != 0;");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("""
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """);
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(sb.ToString());
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        // Should use ulong
+        Assert.Contains(": ulong", generatedSource);
+    }
+
+    [Fact]
+    public void SaveFlags_Over64_UsesMultipleEnums()
+    {
+        // Generate source with 70 fields, all with save flags
+        var sb = new StringBuilder();
+        sb.AppendLine("""
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class HugeFlagItem : ISerializable
+                {
+            """);
+
+        for (int i = 0; i < 70; i++)
+        {
+            sb.AppendLine($"        [SerializableField({i})]");
+            sb.AppendLine($"        private int _field{i};");
+            sb.AppendLine();
+            sb.AppendLine($"        [SerializableFieldSaveFlag({i})]");
+            sb.AppendLine($"        private bool ShouldSerializeField{i}() => _field{i} != 0;");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("""
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """);
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(sb.ToString());
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        // Should have SaveFlag enum with ulong type (for > 32 flags, uses ulong up to 64)
+        // When > 64 flags, should generate multiple enums
+        Assert.Contains("enum SaveFlag", generatedSource);
+        // For 70 flags, need 2 enums (64 + 6)
+        // Check that there are multiple SaveFlag usages (SaveFlag and SaveFlag2 or multiple ulong enums)
+        var saveFlagCount = EnumSaveFlagRegex().Count(generatedSource);
+        Assert.True(saveFlagCount >= 2, $"Expected at least 2 SaveFlag enums, found {saveFlagCount}");
+    }
+
+    [Fact]
+    public void SaveFlagWithDefaultValue_GeneratesDefaultLogic()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class DefaultValueItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private int _count;
+
+                    [SerializableFieldSaveFlag(0)]
+                    private bool ShouldSerializeCount() => _count != 0;
+
+                    [SerializableFieldDefault(0)]
+                    private int GetCountDefault() => 0;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("enum SaveFlag", generatedSource);
+        Assert.Contains("GetCountDefault", generatedSource);
+    }
+
+    [GeneratedRegex("enum SaveFlag")]
+    private static partial Regex EnumSaveFlagRegex();
+}

--- a/ModernUO.Serialization.Generator.Tests/SortedSetComparerTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/SortedSetComparerTests.cs
@@ -1,18 +1,3 @@
-/*************************************************************************
- * ModernUO                                                              *
- * Copyright 2019-2024 - ModernUO Development Team                       *
- * Email: hi@modernuo.com                                                *
- * File: SortedSetComparerTests.cs                                       *
- *                                                                       *
- * This program is free software: you can redistribute it and/or modify  *
- * it under the terms of the GNU General Public License as published by  *
- * the Free Software Foundation, either version 3 of the License, or     *
- * (at your option) any later version.                                   *
- *                                                                       *
- * You should have received a copy of the GNU General Public License     *
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *************************************************************************/
-
 using ModernUO.Serialization.Generator.Tests.Helpers;
 using Xunit;
 

--- a/ModernUO.Serialization.Generator.Tests/SortedSetComparerTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/SortedSetComparerTests.cs
@@ -1,0 +1,225 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2024 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: SortedSetComparerTests.cs                                       *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using ModernUO.Serialization.Generator.Tests.Helpers;
+using Xunit;
+
+namespace ModernUO.Serialization.Generator.Tests;
+
+public class SortedSetComparerTests
+{
+    [Fact]
+    public void SortedSet_WithInstanceComparer_GeneratesCorrectConstructor()
+    {
+        const string source = """
+            using System;
+            using System.Collections.Generic;
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                public class CaseInsensitiveComparer : IComparer<string>
+                {
+                    public int Compare(string x, string y) => string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
+                }
+
+                [SerializationGenerator(0)]
+                public partial class SortedSetItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    [SortedSetComparer(typeof(CaseInsensitiveComparer))]
+                    private SortedSet<string> _names;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+
+        // Should generate constructor with new comparer instance
+        Assert.Contains("new TestNamespace.CaseInsensitiveComparer()", generatedSource);
+    }
+
+    [Fact]
+    public void SortedSet_WithStaticMemberComparer_GeneratesCorrectConstructor()
+    {
+        const string source = """
+            using System;
+            using System.Collections.Generic;
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class SortedSetItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    [SortedSetComparer(typeof(StringComparer), nameof(StringComparer.OrdinalIgnoreCase))]
+                    private SortedSet<string> _names;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+
+        // Should generate constructor with static member reference
+        Assert.Contains("System.StringComparer.OrdinalIgnoreCase", generatedSource);
+    }
+
+    [Fact]
+    public void SortedSet_WithoutComparer_GeneratesDefaultConstructor()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class SortedSetItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private SortedSet<int> _numbers;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+
+        // Should generate constructor without comparer argument
+        Assert.Contains("new System.Collections.Generic.SortedSet<int>();", generatedSource);
+    }
+
+    [Fact]
+    public void SortedSet_StringWithoutComparer_GeneratesDefaultConstructor()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class SortedSetItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    private SortedSet<string> _names;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+
+        // Should generate constructor without comparer argument
+        Assert.Contains("new System.Collections.Generic.SortedSet<string>();", generatedSource);
+    }
+
+    [Fact]
+    public void SortedSet_WithComparerAndCanBeNull_GeneratesCorrectCode()
+    {
+        const string source = """
+            using System;
+            using System.Collections.Generic;
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class SortedSetItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    [CanBeNull]
+                    [SortedSetComparer(typeof(StringComparer), nameof(StringComparer.Ordinal))]
+                    private SortedSet<string> _names;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+
+        // Should include both the null check and the comparer
+        Assert.Contains("reader.ReadBool()", generatedSource);
+        Assert.Contains("System.StringComparer.Ordinal", generatedSource);
+    }
+
+    [Fact]
+    public void SortedSet_WithComparerAndTidy_GeneratesCorrectCode()
+    {
+        const string source = """
+            using System;
+            using System.Collections.Generic;
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial class SortedSetItem : ISerializable
+                {
+                    [SerializableField(0)]
+                    [Tidy]
+                    [SortedSetComparer(typeof(StringComparer), nameof(StringComparer.CurrentCultureIgnoreCase))]
+                    private SortedSet<string> _names;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+
+        // Should include Tidy call and comparer
+        Assert.Contains(".Tidy()", generatedSource);
+        Assert.Contains("System.StringComparer.CurrentCultureIgnoreCase", generatedSource);
+    }
+}

--- a/ModernUO.Serialization.Generator.Tests/StructRecordSerializationTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/StructRecordSerializationTests.cs
@@ -100,7 +100,7 @@ public class StructRecordSerializationTests
             }
             """;
 
-        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+        var (diagnostics, _) = SourceGeneratorTestHelper.RunGenerator(source);
 
         Assert.Contains(diagnostics, d => d.Id == "SG3009");
     }
@@ -183,7 +183,7 @@ public class StructRecordSerializationTests
             }
             """;
 
-        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+        var (diagnostics, _) = SourceGeneratorTestHelper.RunGenerator(source);
 
         Assert.Contains(diagnostics, d => d.Id == "SG3009");
     }

--- a/ModernUO.Serialization.Generator.Tests/StructRecordSerializationTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/StructRecordSerializationTests.cs
@@ -1,18 +1,3 @@
-/*************************************************************************
- * ModernUO                                                              *
- * Copyright 2019-2024 - ModernUO Development Team                       *
- * Email: hi@modernuo.com                                                *
- * File: StructRecordSerializationTests.cs                               *
- *                                                                       *
- * This program is free software: you can redistribute it and/or modify  *
- * it under the terms of the GNU General Public License as published by  *
- * the Free Software Foundation, either version 3 of the License, or     *
- * (at your option) any later version.                                   *
- *                                                                       *
- * You should have received a copy of the GNU General Public License     *
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *************************************************************************/
-
 using ModernUO.Serialization.Generator.Tests.Helpers;
 using Xunit;
 

--- a/ModernUO.Serialization.Generator.Tests/StructRecordSerializationTests.cs
+++ b/ModernUO.Serialization.Generator.Tests/StructRecordSerializationTests.cs
@@ -1,0 +1,228 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2024 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: StructRecordSerializationTests.cs                               *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using ModernUO.Serialization.Generator.Tests.Helpers;
+using Xunit;
+
+namespace ModernUO.Serialization.Generator.Tests;
+
+public class StructRecordSerializationTests
+{
+    [Fact]
+    public void Struct_WithStaticFactory_GeneratesCorrectly()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial struct SimpleStruct
+                {
+                    [SerializableField(0)]
+                    private int _value;
+
+                    public static SimpleStruct Deserialize(IGenericReader reader)
+                    {
+                        return new SimpleStruct();
+                    }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("partial struct SimpleStruct", generatedSource);
+        Assert.Contains("void Serialize(", generatedSource);
+        // Struct should NOT have a serial constructor
+        Assert.DoesNotContain("SimpleStruct(Serial serial)", generatedSource);
+    }
+
+    [Fact]
+    public void Struct_WithInstanceDeserialize_GeneratesCorrectly()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial struct SimpleStruct
+                {
+                    [SerializableField(0)]
+                    private int _value;
+
+                    public void Deserialize(IGenericReader reader)
+                    {
+                    }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("partial struct SimpleStruct", generatedSource);
+    }
+
+    [Fact]
+    public void Struct_WithoutDeserializeMethod_ReportsDiagnostic()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial struct BadStruct
+                {
+                    [SerializableField(0)]
+                    private int _value;
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "SG3009");
+    }
+
+    [Fact]
+    public void Record_GeneratesCorrectly()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial record SimpleRecord : ISerializable
+                {
+                    [SerializableField(0)]
+                    private string _name;
+
+                    public Serial Serial => default;
+                    public void MarkDirty() { }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("partial record SimpleRecord", generatedSource);
+    }
+
+    [Fact]
+    public void RecordStruct_WithStaticFactory_GeneratesCorrectly()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial record struct SimpleRecordStruct
+                {
+                    [SerializableField(0)]
+                    private int _value;
+
+                    public static SimpleRecordStruct Deserialize(IGenericReader reader)
+                    {
+                        return new SimpleRecordStruct();
+                    }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("partial record struct SimpleRecordStruct", generatedSource);
+        // Record struct should NOT have a serial constructor
+        Assert.DoesNotContain("SimpleRecordStruct(Serial serial)", generatedSource);
+    }
+
+    [Fact]
+    public void RecordStruct_WithoutDeserializeMethod_ReportsDiagnostic()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial record struct BadRecordStruct
+                {
+                    [SerializableField(0)]
+                    private int _value;
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "SG3009");
+    }
+
+    [Fact]
+    public void Struct_MultipleFields_GeneratesCorrectly()
+    {
+        const string source = """
+            using ModernUO.Serialization;
+            using Server;
+
+            namespace TestNamespace
+            {
+                [SerializationGenerator(0)]
+                public partial struct MultiFieldStruct
+                {
+                    [SerializableField(0)]
+                    private int _x;
+
+                    [SerializableField(1)]
+                    private int _y;
+
+                    [SerializableField(2)]
+                    private int _z;
+
+                    public static MultiFieldStruct Deserialize(IGenericReader reader)
+                    {
+                        return new MultiFieldStruct();
+                    }
+                }
+            }
+            """;
+
+        var (diagnostics, generatedSource) = SourceGeneratorTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("public int X", generatedSource);
+        Assert.Contains("public int Y", generatedSource);
+        Assert.Contains("public int Z", generatedSource);
+    }
+}

--- a/ModernUO.Serialization.Generator/Diagnostics/DiagnosticDescriptors.cs
+++ b/ModernUO.Serialization.Generator/Diagnostics/DiagnosticDescriptors.cs
@@ -24,8 +24,8 @@ public static class DiagnosticDescriptors
 {
     public static readonly DiagnosticDescriptor SG3001 = new(
         "SG3001",
-        "Classes marked with the SerializationGenerator attribute must be partial",
-        "'{0}' must be a partial class to use the SerializationGenerator attribute",
+        "Types marked with the SerializationGenerator attribute must be partial",
+        "'{0}' must be a partial type to use the SerializationGenerator attribute",
         "ModernUO.Serialization.Generator",
         DiagnosticSeverity.Error,
         true
@@ -33,7 +33,7 @@ public static class DiagnosticDescriptors
 
     public static readonly DiagnosticDescriptor SG3002 = new(
         "SG3002",
-        "Classes marked with the SerializationGenerator attribute must properly import the attribute",
+        "Types marked with the SerializationGenerator attribute must properly import the attribute",
         "'{0}' is not properly importing the SerializationGenerator attribute",
         "ModernUO.Serialization.Generator",
         DiagnosticSeverity.Error,
@@ -89,6 +89,15 @@ public static class DiagnosticDescriptors
         "SG3008",
         "Missing DeserializeTimerField attribute",
         "Missing DeserializeTimerField attribute for '{0}'",
+        "ModernUO.Serialization.Generator",
+        DiagnosticSeverity.Error,
+        true
+    );
+
+    public static readonly DiagnosticDescriptor SG3009 = new(
+        "SG3009",
+        "Struct/record must have a Deserialize method",
+        "'{0}' must have either a static 'Deserialize(IGenericReader)' factory method or an instance 'void Deserialize(IGenericReader)' method",
         "ModernUO.Serialization.Generator",
         DiagnosticSeverity.Error,
         true

--- a/ModernUO.Serialization.Generator/EntitySerializationGenerator.cs
+++ b/ModernUO.Serialization.Generator/EntitySerializationGenerator.cs
@@ -86,35 +86,43 @@ public class EntitySerializationGenerator(bool generateMigrations = false) : IIn
 
         var syntaxNode = (AttributeSyntax)ctx.Node;
 
-        if (syntaxNode.Parent?.Parent is not ClassDeclarationSyntax classNode)
+        if (syntaxNode.Parent?.Parent is not TypeDeclarationSyntax typeNode)
         {
             return null;
         }
 
-        if (!classNode.IsPartial())
+        if (!typeNode.IsPartial())
         {
-            var className = compilation
-                .GetSemanticModel(classNode.SyntaxTree)
-                .GetDeclaredSymbol(classNode)?
+            var typeName = compilation
+                .GetSemanticModel(typeNode.SyntaxTree)
+                .GetDeclaredSymbol(typeNode)?
                 .Name;
 
-            var diagnostic = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3001, className);
+            var diagnostic = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3001, typeName);
             return (null, [diagnostic]);
         }
 
-        var node = (ClassDeclarationSyntax)ctx.Node.Parent!.Parent!;
+        var node = (TypeDeclarationSyntax)ctx.Node.Parent!.Parent!;
         var classSymbol = ctx.SemanticModel.GetDeclaredSymbol(node) as INamedTypeSymbol;
 
         // This happens when there is no using import
         if (!classSymbol.TryGetSerializable(compilation, out var serializationAttribute))
         {
-            var className = compilation
-                .GetSemanticModel(classNode.SyntaxTree)
-                .GetDeclaredSymbol(classNode)?
+            var typeName = compilation
+                .GetSemanticModel(typeNode.SyntaxTree)
+                .GetDeclaredSymbol(typeNode)?
                 .Name;
 
-            var diagnostic = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3002, className);
+            var diagnostic = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3002, typeName);
 
+            return (null, [diagnostic]);
+        }
+
+        // Validate that structs/records have deserialization capability
+        if (classSymbol.IsValueType && !classSymbol.HasDeserializationCapability(compilation, out _))
+        {
+            var typeName = classSymbol.Name;
+            var diagnostic = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3009, typeName);
             return (null, [diagnostic]);
         }
 
@@ -177,7 +185,7 @@ public class EntitySerializationGenerator(bool generateMigrations = false) : IIn
         }
 
         var record = new SerializableClassRecord(
-            classNode,
+            typeNode,
             classSymbol,
             serializationAttribute,
             fields.ToImmutable(),
@@ -208,7 +216,9 @@ public class EntitySerializationGenerator(bool generateMigrations = false) : IIn
 
         if (classRecord != null)
         {
-            if (additionalTexts.TryGetValue(classRecord.ClassSymbol.ToDisplayString(), out var migs))
+            // Use arity notation for generic types to match migration file naming
+            var migrationKey = classRecord.ClassSymbol.GetGenericArityName();
+            if (additionalTexts.TryGetValue(migrationKey, out var migs))
             {
                 classRecord = classRecord with
                 {
@@ -288,8 +298,9 @@ public class EntitySerializationGenerator(bool generateMigrations = false) : IIn
 
                 if (classSource != null)
                 {
+                    // Use arity notation for generic types to avoid invalid characters in filename
                     context.AddSource(
-                        $"{classRecord.ClassSymbol.ToDisplayString()}.Serialization.g.cs",
+                        $"{classRecord.ClassSymbol.GetGenericArityName()}.Serialization.g.cs",
                         SourceText.From(classSource, Encoding.UTF8)
                     );
 
@@ -309,7 +320,7 @@ public class EntitySerializationGenerator(bool generateMigrations = false) : IIn
             catch (Exception e)
             {
                 var descriptor = DiagnosticDescriptors.GeneratorCrashedDiagnostic(e);
-                var diagnostic = classRecord.ClassNode.GenerateDiagnostic(
+                var diagnostic = classRecord.TypeNode.GenerateDiagnostic(
                     descriptor,
                     e.GetType(),
                     classRecord.ClassSymbol.Name,

--- a/ModernUO.Serialization.Generator/EntitySerializationGenerator.cs
+++ b/ModernUO.Serialization.Generator/EntitySerializationGenerator.cs
@@ -245,7 +245,11 @@ public class EntitySerializationGenerator(bool generateMigrations = false) : IIn
                 builder[className] = classMigrationSet = new Dictionary<int, AdditionalText>();
             }
 
-            classMigrationSet[version] = additionalText;
+            // Only use the first migration file for each version to prevent silent overwrites
+            if (!classMigrationSet.ContainsKey(version))
+            {
+                classMigrationSet[version] = additionalText;
+            }
         }
 
         return builder.ToImmutable();

--- a/ModernUO.Serialization.Generator/ModernUO.Serialization.Generator.csproj
+++ b/ModernUO.Serialization.Generator/ModernUO.Serialization.Generator.csproj
@@ -4,8 +4,8 @@
         <PackageId>ModernUO.Serialization.Generator</PackageId>
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>preview</LangVersion>
-        <AssemblyVersion>2.13.0</AssemblyVersion>
-        <PackageVersion>2.13.0</PackageVersion>
+        <AssemblyVersion>2.14.1</AssemblyVersion>
+        <PackageVersion>2.14.1</PackageVersion>
         <AssemblyName>ModernUO.Serialization.Generator</AssemblyName>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -15,15 +15,16 @@
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <PackageProjectUrl>https://github.com/modernuo/SerializationGenerator</PackageProjectUrl>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+        <Description>Source generator for ModernUO Serialization</Description>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
-        <PackageReference Include="Humanizer.Core" Version="2.14.1" GeneratePathProperty="true" PrivateAssets="all" />
-        <PackageReference Include="System.Text.Json" Version="10.0.0" GeneratePathProperty="true" PrivateAssets="all" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.0" GeneratePathProperty="true" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" GeneratePathProperty="true" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
+        <PackageReference Include="Humanizer.Core" Version="3.0.1" GeneratePathProperty="true" PrivateAssets="all" />
+        <PackageReference Include="System.Text.Json" Version="10.0.1" GeneratePathProperty="true" PrivateAssets="all" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.1" GeneratePathProperty="true" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.1" GeneratePathProperty="true" PrivateAssets="all" />
 
         <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
 

--- a/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableClassRecord.cs
+++ b/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableClassRecord.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace ModernUO.Serialization.Generator;
 
 public record SerializableClassRecord(
-    ClassDeclarationSyntax ClassNode,
+    TypeDeclarationSyntax TypeNode,
     INamedTypeSymbol ClassSymbol,
     AttributeData SerializationAttribute,
     ImmutableArray<(ISymbol, AttributeData)> SerializableFields,
@@ -14,4 +14,7 @@ public record SerializableClassRecord(
     ImmutableArray<(ISymbol, AttributeData)> SerializableFieldDefault,
     ISymbol? DirtyTrackingEntity,
     ImmutableDictionary<int, AdditionalText> Migrations
-);
+)
+{
+    public bool IsValueType => ClassSymbol.IsValueType;
+};

--- a/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableEntityGeneration.Class.cs
+++ b/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableEntityGeneration.Class.cs
@@ -41,7 +41,7 @@ public static partial class SerializableEntityGeneration
         token.ThrowIfCancellationRequested();
 
         var (
-            classNode,
+            typeNode,
             classSymbol,
             serializableAttr,
             fields,
@@ -51,6 +51,9 @@ public static partial class SerializableEntityGeneration
             dirtyTrackingEntity,
             migrations
         ) = classRecord;
+
+        var typeKeyword = typeNode.GetTypeKeyword();
+        var isValueType = classRecord.IsValueType;
 
         // If we have a parent that is or derives from ISerializable, then we are in override
         var isOverride = classSymbol.BaseType.HasSerializableInterface(compilation);
@@ -68,14 +71,14 @@ public static partial class SerializableEntityGeneration
 
             if (order < 0)
             {
-                var diag = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3006, SymbolMetadata.SERIALIZABLE_FIELD_SAVE_FLAG_ATTRIBUTE, symbol.Name);
+                var diag = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3006, SymbolMetadata.SERIALIZABLE_FIELD_SAVE_FLAG_ATTRIBUTE, symbol.Name);
                 return (null, null, [diag]);
             }
 
             // Duplicate found, failure.
             if (serializableFieldSaveFlags.TryGetValue(order, out _))
             {
-                var diag = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3003, SymbolMetadata.SERIALIZABLE_FIELD_SAVE_FLAG_ATTRIBUTE, order);
+                var diag = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3003, SymbolMetadata.SERIALIZABLE_FIELD_SAVE_FLAG_ATTRIBUTE, order);
                 return (null, null, [diag]);
             }
 
@@ -92,7 +95,7 @@ public static partial class SerializableEntityGeneration
 
             if (order < 0)
             {
-                var diag = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3006, SymbolMetadata.SERIALIZABLE_FIELD_DEFAULT_ATTRIBUTE, symbol.Name);
+                var diag = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3006, SymbolMetadata.SERIALIZABLE_FIELD_DEFAULT_ATTRIBUTE, symbol.Name);
                 return (null, null, [diag]);
             }
 
@@ -105,7 +108,7 @@ public static partial class SerializableEntityGeneration
             // Duplicate found, failure.
             if (serializableFieldSaveFlagMethods.GetFieldDefaultValue != null)
             {
-                var diag = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3003, SymbolMetadata.SERIALIZABLE_FIELD_DEFAULT_ATTRIBUTE, order);
+                var diag = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3003, SymbolMetadata.SERIALIZABLE_FIELD_DEFAULT_ATTRIBUTE, order);
                 return (null, null, [diag]);
             }
 
@@ -136,7 +139,7 @@ public static partial class SerializableEntityGeneration
 
         var indent = "    ";
 
-        source.RecursiveGenerateClassStart(classSymbol, ImmutableArray<ITypeSymbol>.Empty, ref indent);
+        source.RecursiveGenerateClassStart(classSymbol, ImmutableArray<ITypeSymbol>.Empty, ref indent, typeKeyword);
 
         source.GenerateField(
             indent,
@@ -212,7 +215,7 @@ public static partial class SerializableEntityGeneration
 
             if (order < 0)
             {
-                var diag = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3006, SymbolMetadata.SERIALIZABLE_PROPERTY_ATTRIBUTE, symbol.Name);
+                var diag = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3006, SymbolMetadata.SERIALIZABLE_PROPERTY_ATTRIBUTE, symbol.Name);
                 return (null, null, [diag]);
             }
 
@@ -242,7 +245,7 @@ public static partial class SerializableEntityGeneration
                     if (classSymbol.GetMembers(fieldName)
                             .FirstOrDefault(member => member is IFieldSymbol) is not IFieldSymbol fieldMember)
                     {
-                        var diag = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3004, fieldName, order);
+                        var diag = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3004, fieldName, order);
                         return (null, null, [diag]);
                     }
 
@@ -268,13 +271,13 @@ public static partial class SerializableEntityGeneration
                     // We can't continue if we have duplicates.
                     if (!serializableFieldSet.Add(serializableProperty))
                     {
-                        var diag = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3003, SymbolMetadata.SERIALIZABLE_PROPERTY_ATTRIBUTE, order);
+                        var diag = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3003, SymbolMetadata.SERIALIZABLE_PROPERTY_ATTRIBUTE, order);
                         return (null, null, [diag]);
                     }
                 }
                 catch (NoRuleFoundException e)
                 {
-                    var diag = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3007, e.PropertyName, e.PropertyType);
+                    var diag = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3007, e.PropertyName, e.PropertyType);
                     return (null, null, [diag]);
                 }
             }
@@ -318,7 +321,7 @@ public static partial class SerializableEntityGeneration
 
             if (order < 0)
             {
-                var diag = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3006, SymbolMetadata.SERIALIZABLE_FIELD_ATTRIBUTE, symbol.Name);
+                var diag = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3006, SymbolMetadata.SERIALIZABLE_FIELD_ATTRIBUTE, symbol.Name);
                 return (null, null, [diag]);
             }
 
@@ -381,13 +384,13 @@ public static partial class SerializableEntityGeneration
                     // We can't continue if we have duplicates.
                     if (!serializableFieldSet.Add(serializableProperty))
                     {
-                        var diag = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3003, SymbolMetadata.SERIALIZABLE_FIELD_ATTRIBUTE, order);
+                        var diag = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3003, SymbolMetadata.SERIALIZABLE_FIELD_ATTRIBUTE, order);
                         return (null, null, [diag]);
                     }
                 }
                 catch (NoRuleFoundException e)
                 {
-                    var diag = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3007, e.PropertyName, e.PropertyType);
+                    var diag = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3007, e.PropertyName, e.PropertyType);
                     return (null, null, [diag]);
                 }
             }
@@ -402,12 +405,13 @@ public static partial class SerializableEntityGeneration
             var order = serializableFields[i].Order;
             if (order != i)
             {
-                var diag = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3005, serializableFields[i].Name, i, order);
+                var diag = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3005, serializableFields[i].Name, i, order);
                 return (null, null, [diag]);
             }
         }
 
-        if (isSerializable && !classSymbol.HasSerialCtor(compilation))
+        // Skip serial constructor for value types - they use static factory or instance Deserialize
+        if (!isValueType && isSerializable && !classSymbol.HasSerialCtor(compilation))
         {
             // Serial constructor
             source.GenerateSerialCtor(compilation, className, indent, isOverride);
@@ -523,7 +527,7 @@ public static partial class SerializableEntityGeneration
         }
         catch (DeserializeTimerFieldRequiredException e)
         {
-            var diag = classNode.GenerateDiagnostic(DiagnosticDescriptors.SG3008, e.PropertyName);
+            var diag = typeNode.GenerateDiagnostic(DiagnosticDescriptors.SG3008, e.PropertyName);
             return (null, null, [diag]);
         }
 
@@ -598,57 +602,63 @@ public static partial class SerializableEntityGeneration
         source.GenerateNamespaceEnd();
 
         // Write the migration file (exclude readonly fields since they aren't serialized)
+        // Use arity notation for generic types to match file naming convention
         var serializableFieldsForMigration = serializableFields.Where(f => !f.IsReadOnly).ToImmutableArray();
         var newMigration = generateMetadata ? new SerializableMetadata
         {
             Version = version,
-            Type = classSymbol.ToDisplayString(),
+            Type = classSymbol.GetGenericArityName(),
             Properties = serializableFieldsForMigration.Length > 0 ? serializableFieldsForMigration : null
         } : null;
 
         return (source.ToString(), newMigration, null);
     }
 
-    private static void RecursiveGenerateClassStart(
-        this StringBuilder source,
-        INamedTypeSymbol classSymbol,
-        ImmutableArray<ITypeSymbol> interfaces,
-        ref string indent
-    )
+    extension(StringBuilder source)
     {
-        var containingSymbolList = new List<INamedTypeSymbol>();
-
-        do
+        private void RecursiveGenerateClassStart(
+            INamedTypeSymbol classSymbol,
+            ImmutableArray<ITypeSymbol> interfaces,
+            ref string indent,
+            string typeKeyword = "class"
+        )
         {
-            containingSymbolList.Add(classSymbol);
-            classSymbol = classSymbol.ContainingSymbol as INamedTypeSymbol;
-        } while (classSymbol != null);
+            var containingSymbolList = new List<INamedTypeSymbol>();
 
-        containingSymbolList.Reverse();
-
-        for (var i = 0; i < containingSymbolList.Count; i++)
-        {
-            var symbol = containingSymbolList[i];
-            var last = i == containingSymbolList.Count - 1;
-
-            if (last)
+            do
             {
-                source.AppendLine($"{indent}[System.CodeDom.Compiler.GeneratedCode(\"ModernUO.Serialization.Generator\", \"{Version}\")]");
+                containingSymbolList.Add(classSymbol);
+                classSymbol = classSymbol.ContainingSymbol as INamedTypeSymbol;
+            } while (classSymbol != null);
+
+            containingSymbolList.Reverse();
+
+            for (var i = 0; i < containingSymbolList.Count; i++)
+            {
+                var symbol = containingSymbolList[i];
+                var last = i == containingSymbolList.Count - 1;
+
+                if (last)
+                {
+                    source.AppendLine($"{indent}[System.CodeDom.Compiler.GeneratedCode(\"ModernUO.Serialization.Generator\", \"{Version}\")]");
+                }
+
+                // Only the outermost type uses the specified type keyword
+                var currentTypeKeyword = last ? typeKeyword : "class";
+                source.GenerateClassStart(symbol, indent, last ? interfaces : ImmutableArray<ITypeSymbol>.Empty, true, currentTypeKeyword);
+                indent += "    ";
             }
-
-            source.GenerateClassStart(symbol, indent, last ? interfaces : ImmutableArray<ITypeSymbol>.Empty);
-            indent += "    ";
         }
-    }
 
-    private static void RecursiveGenerateClassEnd(this StringBuilder source, INamedTypeSymbol classSymbol, ref string indent)
-    {
-        do
+        private void RecursiveGenerateClassEnd(INamedTypeSymbol classSymbol, ref string indent)
         {
-            indent = indent.Substring(0, indent.Length - 4);
-            source.GenerateClassEnd(indent);
+            do
+            {
+                indent = indent.Substring(0, indent.Length - 4);
+                source.GenerateClassEnd(indent);
 
-            classSymbol = classSymbol.ContainingSymbol as INamedTypeSymbol;
-        } while (classSymbol != null);
+                classSymbol = classSymbol.ContainingSymbol as INamedTypeSymbol;
+            } while (classSymbol != null);
+        }
     }
 }

--- a/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableEntityGeneration.Class.cs
+++ b/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableEntityGeneration.Class.cs
@@ -555,6 +555,13 @@ public static partial class SerializableEntityGeneration
                         source.GenerateEnumEnd(indent);
                     }
 
+                    // If we're starting a new enum due to overflow, increment the enum index first
+                    if (currentBitIndex >= bitsPerEnum)
+                    {
+                        currentBitIndex = 0;
+                        currentEnumIndex++;
+                    }
+
                     source.AppendLine();
                     var enumName = currentEnumIndex == 0 ? "SaveFlag" : $"SaveFlag{currentEnumIndex + 1}";
                     source.GenerateEnumStart(
@@ -574,11 +581,6 @@ public static partial class SerializableEntityGeneration
                         source.GenerateEnumValue($"{indent}    ", true, "None", -1);
                     }
 
-                    if (currentBitIndex >= bitsPerEnum)
-                    {
-                        currentBitIndex = 0;
-                        currentEnumIndex++;
-                    }
                     isFirstEnum = false;
                 }
 

--- a/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableEntityGeneration.Class.cs
+++ b/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableEntityGeneration.Class.cs
@@ -21,7 +21,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 
@@ -329,25 +328,33 @@ public static partial class SerializableEntityGeneration
 
             if (symbol is IFieldSymbol fieldSymbol)
             {
+                // Readonly fields cannot have setters - force to null
+                var effectiveSetterAccessor = fieldSymbol.IsReadOnly ? (Accessibility?)null : setterAccessor;
+
                 source.GenerateSerializableProperty(
                     compilation,
                     indent,
                     fieldSymbol,
                     getterAccessor,
-                    setterAccessor,
+                    effectiveSetterAccessor,
                     virtualProperty,
                     markDirtyMethod
                 );
                 source.AppendLine();
 
-                var propertyAccessor = setterAccessor > getterAccessor ? setterAccessor : getterAccessor;
-                var generatedDataStructureMethods = source.GenerateDataStructureMethods(
-                    compilation,
-                    indent,
-                    fieldSymbol,
-                    propertyAccessor.ToFriendlyString(),
-                    markDirtyMethod
-                );
+                // Skip data structure methods for readonly fields (they cannot be modified)
+                var generatedDataStructureMethods = false;
+                if (!fieldSymbol.IsReadOnly)
+                {
+                    var propertyAccessor = setterAccessor > getterAccessor ? setterAccessor : getterAccessor;
+                    generatedDataStructureMethods = source.GenerateDataStructureMethods(
+                        compilation,
+                        indent,
+                        fieldSymbol,
+                        propertyAccessor.ToFriendlyString(),
+                        markDirtyMethod
+                    );
+                }
 
                 if (generatedDataStructureMethods)
                 {
@@ -367,7 +374,8 @@ public static partial class SerializableEntityGeneration
                         classSymbol,
                         serializableFieldSaveFlagMethods
                     ) with {
-                        FieldName = fieldSymbol.Name
+                        FieldName = fieldSymbol.Name,
+                        IsReadOnly = fieldSymbol.IsReadOnly
                     };
 
                     // We can't continue if we have duplicates.
@@ -424,10 +432,17 @@ public static partial class SerializableEntityGeneration
             }
 
             var chrArray = ArrayPool<char>.Shared.Rent(migrationSource.Length);
-            migrationSource.CopyTo(0, chrArray, 0, migrationSource.Length);
-            ReadOnlySpan<char> buffer = chrArray.AsSpan(0, migrationSource.Length);
-            SerializableMetadata migration = JsonSerializer.Deserialize<SerializableMetadata>(buffer, jsonSerializerOptions);
-            ArrayPool<char>.Shared.Return(chrArray);
+            SerializableMetadata migration;
+            try
+            {
+                migrationSource.CopyTo(0, chrArray, 0, migrationSource.Length);
+                ReadOnlySpan<char> buffer = chrArray.AsSpan(0, migrationSource.Length);
+                migration = JsonSerializer.Deserialize<SerializableMetadata>(buffer, jsonSerializerOptions);
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(chrArray);
+            }
 
             source.GenerateMigrationContentStruct(compilation, indent, migration, classSymbol);
             source.AppendLine();
@@ -437,6 +452,41 @@ public static partial class SerializableEntityGeneration
 
         var serializeOverride = isOverride || classSymbol.BaseType.IsSerializableRecursive(compilation);
 
+        // Compute SaveFlag configuration
+        // Maps field order to (enumIndex, bitIndex) for fields with save flags
+        var saveFlagMapping = new Dictionary<int, (int EnumIndex, int BitIndex)>();
+        var saveFlagCount = 0;
+        foreach (var (order, _) in serializableFieldSaveFlags)
+        {
+            if (!serializableFields[order].IsReadOnly)
+            {
+                saveFlagCount++;
+            }
+        }
+
+        var saveFlagUseUlong = saveFlagCount > 32;
+        var saveFlagEnumCount = saveFlagCount <= 64 ? 1 : (saveFlagCount + 63) / 64;
+        var bitsPerEnum = saveFlagUseUlong ? 64 : 32;
+
+        var currentBitIndex = 0;
+        var currentEnumIndex = 0;
+        foreach (var (order, _) in serializableFieldSaveFlags)
+        {
+            if (serializableFields[order].IsReadOnly)
+            {
+                continue;
+            }
+
+            if (currentBitIndex >= bitsPerEnum)
+            {
+                currentBitIndex = 0;
+                currentEnumIndex++;
+            }
+
+            saveFlagMapping[order] = (currentEnumIndex, currentBitIndex);
+            currentBitIndex++;
+        }
+
         // Serialize Method
         source.GenerateSerializeMethod(
             compilation,
@@ -444,7 +494,10 @@ public static partial class SerializableEntityGeneration
             serializeOverride,
             encodedVersion,
             serializableFields,
-            serializableFieldSaveFlags
+            serializableFieldSaveFlags,
+            saveFlagMapping,
+            saveFlagUseUlong,
+            saveFlagEnumCount
         );
         source.AppendLine();
 
@@ -462,7 +515,10 @@ public static partial class SerializableEntityGeneration
                 serializableFields,
                 markDirtyMethod,
                 dirtyTrackingEntity?.Name ?? "this",
-                serializableFieldSaveFlags
+                serializableFieldSaveFlags,
+                saveFlagMapping,
+                saveFlagUseUlong,
+                saveFlagEnumCount
             );
         }
         catch (DeserializeTimerFieldRequiredException e)
@@ -471,36 +527,83 @@ public static partial class SerializableEntityGeneration
             return (null, null, [diag]);
         }
 
-        // Serialize SaveFlag enum class
-        if (serializableFieldSaveFlags.Count > 0)
+        // Serialize SaveFlag enum class(es)
+        if (saveFlagCount > 0)
         {
-            source.AppendLine();
-            source.GenerateEnumStart(
-                "SaveFlag",
-                indent,
-                true,
-                Accessibility.Private
-            );
+            // Reset for enum generation
+            currentBitIndex = 0;
+            currentEnumIndex = 0;
+            var isFirstEnum = true;
 
-            source.GenerateEnumValue($"{indent}    ", true, "None", -1);
-            int index = 0;
             foreach (var (order, _) in serializableFieldSaveFlags)
             {
-                source.GenerateEnumValue($"{indent}    ", true, serializableFields[order].Name, index++);
+                // Skip readonly fields
+                if (serializableFields[order].IsReadOnly)
+                {
+                    continue;
+                }
+
+                // Start a new enum if needed
+                if (currentBitIndex == 0 || currentBitIndex >= bitsPerEnum)
+                {
+                    if (!isFirstEnum)
+                    {
+                        source.GenerateEnumEnd(indent);
+                    }
+
+                    source.AppendLine();
+                    var enumName = currentEnumIndex == 0 ? "SaveFlag" : $"SaveFlag{currentEnumIndex + 1}";
+                    source.GenerateEnumStart(
+                        enumName,
+                        indent,
+                        true,
+                        Accessibility.Private,
+                        saveFlagUseUlong ? "ulong" : null
+                    );
+
+                    if (saveFlagUseUlong)
+                    {
+                        source.GenerateEnumValueLong($"{indent}    ", true, "None", -1);
+                    }
+                    else
+                    {
+                        source.GenerateEnumValue($"{indent}    ", true, "None", -1);
+                    }
+
+                    if (currentBitIndex >= bitsPerEnum)
+                    {
+                        currentBitIndex = 0;
+                        currentEnumIndex++;
+                    }
+                    isFirstEnum = false;
+                }
+
+                if (saveFlagUseUlong)
+                {
+                    source.GenerateEnumValueLong($"{indent}    ", true, serializableFields[order].Name, currentBitIndex++);
+                }
+                else
+                {
+                    source.GenerateEnumValue($"{indent}    ", true, serializableFields[order].Name, currentBitIndex++);
+                }
             }
 
-            source.GenerateEnumEnd(indent);
+            if (!isFirstEnum)
+            {
+                source.GenerateEnumEnd(indent);
+            }
         }
 
         source.RecursiveGenerateClassEnd(classSymbol, ref indent);
         source.GenerateNamespaceEnd();
 
-        // Write the migration file
+        // Write the migration file (exclude readonly fields since they aren't serialized)
+        var serializableFieldsForMigration = serializableFields.Where(f => !f.IsReadOnly).ToImmutableArray();
         var newMigration = generateMetadata ? new SerializableMetadata
         {
             Version = version,
             Type = classSymbol.ToDisplayString(),
-            Properties = serializableFields.Length > 0 ? serializableFields : null
+            Properties = serializableFieldsForMigration.Length > 0 ? serializableFieldsForMigration : null
         } : null;
 
         return (source.ToString(), newMigration, null);

--- a/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableEntityGeneration.DeserializeMethod.cs
+++ b/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableEntityGeneration.DeserializeMethod.cs
@@ -35,7 +35,10 @@ public static partial class SerializableEntityGeneration
         ImmutableArray<SerializableProperty> fields,
         string? markDirtyMethod,
         string? parentReference,
-        SortedDictionary<int, SerializableFieldSaveFlagMethods> serializableFieldSaveFlagMethodsDictionary
+        SortedDictionary<int, SerializableFieldSaveFlagMethods> serializableFieldSaveFlagMethodsDictionary,
+        Dictionary<int, (int EnumIndex, int BitIndex)> saveFlagMapping,
+        bool saveFlagUseUlong,
+        int saveFlagEnumCount
     )
     {
         var genericReaderInterface = compilation.GetTypeByMetadataName(SymbolMetadata.GENERIC_READER_INTERFACE);
@@ -123,31 +126,47 @@ public static partial class SerializableEntityGeneration
             }
         }
 
-        if (serializableFieldSaveFlagMethodsDictionary.Count > 0)
+        if (saveFlagMapping.Count > 0)
         {
             source.AppendLine();
-            source.AppendLine($"{bodyIndent}var saveFlags = reader.ReadEnum<SaveFlag>();");
+            // Read all save flag enums
+            for (var i = 0; i < saveFlagEnumCount; i++)
+            {
+                var enumName = i == 0 ? "SaveFlag" : $"SaveFlag{i + 1}";
+                var varName = i == 0 ? "saveFlags" : $"saveFlags{i + 1}";
+                source.AppendLine($"{bodyIndent}var {varName} = reader.ReadEnum<{enumName}>();");
+            }
         }
 
         for (var i = 0; i < fields.Length; i++)
         {
             var field = fields[i];
+
+            // Skip readonly fields - they cannot be assigned outside the constructor
+            if (field.IsReadOnly)
+            {
+                continue;
+            }
+
             var rule = SerializableMigrationRulesEngine.Rules[field.Rule];
 
             if (serializableFieldSaveFlagMethodsDictionary.TryGetValue(
                     field.Order,
                     out var serializableFieldSaveFlagMethods
-                ))
+                ) && saveFlagMapping.TryGetValue(field.Order, out var mapping))
             {
+                var enumName = mapping.EnumIndex == 0 ? "SaveFlag" : $"SaveFlag{mapping.EnumIndex + 1}";
+                var varName = mapping.EnumIndex == 0 ? "saveFlags" : $"saveFlags{mapping.EnumIndex + 1}";
+
                 source.AppendLine();
                 // Special case
                 if (field.Type == "bool")
                 {
-                    source.AppendLine($"{bodyIndent}{field.FieldName} = (saveFlags & SaveFlag.{field.Name}) != 0;");
+                    source.AppendLine($"{bodyIndent}{field.FieldName} = ({varName} & {enumName}.{field.Name}) != 0;");
                 }
                 else
                 {
-                    source.AppendLine($"{bodyIndent}if ((saveFlags & SaveFlag.{field.Name}) != 0)\n{bodyIndent}{{");
+                    source.AppendLine($"{bodyIndent}if (({varName} & {enumName}.{field.Name}) != 0)\n{bodyIndent}{{");
                     rule.GenerateDeserializationMethod(
                         source,
                         innerIndent,

--- a/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableEntityGeneration.DeserializeMethod.cs
+++ b/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableEntityGeneration.DeserializeMethod.cs
@@ -23,213 +23,215 @@ namespace ModernUO.Serialization.Generator;
 
 public static partial class SerializableEntityGeneration
 {
-    public static void GenerateDeserializeMethod(
-        this StringBuilder source,
-        Compilation compilation,
-        INamedTypeSymbol classSymbol,
-        string indent,
-        bool isOverride,
-        int version,
-        bool encodedVersion,
-        ImmutableArray<SerializableMetadata> migrations,
-        ImmutableArray<SerializableProperty> fields,
-        string? markDirtyMethod,
-        string? parentReference,
-        SortedDictionary<int, SerializableFieldSaveFlagMethods> serializableFieldSaveFlagMethodsDictionary,
-        Dictionary<int, (int EnumIndex, int BitIndex)> saveFlagMapping,
-        bool saveFlagUseUlong,
-        int saveFlagEnumCount
-    )
+    extension(StringBuilder source)
     {
-        var genericReaderInterface = compilation.GetTypeByMetadataName(SymbolMetadata.GENERIC_READER_INTERFACE);
-
-        source.GenerateMethodStart(
-            indent,
-            "Deserialize",
-            Accessibility.Public,
-            isOverride,
-            "void",
-            ImmutableArray.Create<(ITypeSymbol, string)>((genericReaderInterface, "reader"))
-        );
-
-        var bodyIndent = $"{indent}    ";
-        var innerIndent = $"{bodyIndent}    ";
-
-        if (isOverride)
+        public void GenerateDeserializeMethod(
+            Compilation compilation,
+            INamedTypeSymbol classSymbol,
+            string indent,
+            bool isOverride,
+            int version,
+            bool encodedVersion,
+            ImmutableArray<SerializableMetadata> migrations,
+            ImmutableArray<SerializableProperty> fields,
+            string markDirtyMethod,
+            string parentReference,
+            SortedDictionary<int, SerializableFieldSaveFlagMethods> serializableFieldSaveFlagMethodsDictionary,
+            Dictionary<int, (int EnumIndex, int BitIndex)> saveFlagMapping,
+            bool saveFlagUseUlong,
+            int saveFlagEnumCount
+        )
         {
-            source.AppendLine($"{bodyIndent}base.Deserialize(reader);");
-            source.AppendLine();
-        }
+            var genericReaderInterface = compilation.GetTypeByMetadataName(SymbolMetadata.GENERIC_READER_INTERFACE);
 
-        var afterDeserialization = classSymbol
-            .GetMembers()
-            .OfType<IMethodSymbol>()
-            .Select(
-                m =>
-                {
-                    if (!m.ReturnsVoid || m.Parameters.Length != 0)
+            source.GenerateMethodStart(
+                indent,
+                "Deserialize",
+                Accessibility.Public,
+                isOverride,
+                "void",
+                ImmutableArray.Create<(ITypeSymbol, string)>((genericReaderInterface, "reader"))
+            );
+
+            var bodyIndent = $"{indent}    ";
+            var innerIndent = $"{bodyIndent}    ";
+
+            if (isOverride)
+            {
+                source.AppendLine($"{bodyIndent}base.Deserialize(reader);");
+                source.AppendLine();
+            }
+
+            var afterDeserialization = classSymbol
+                .GetMembers()
+                .OfType<IMethodSymbol>()
+                .Select(
+                    m =>
                     {
-                        return (m, null);
+                        if (!m.ReturnsVoid || m.Parameters.Length != 0)
+                        {
+                            return (m, null);
+                        }
+
+                        return (m, m.GetAttributes()
+                            .FirstOrDefault(
+                                attr => SymbolEqualityComparer.Default.Equals(
+                                    attr.AttributeClass,
+                                    compilation.GetTypeByMetadataName(SymbolMetadata.AFTER_DESERIALIZATION_ATTRIBUTE)
+                                )
+                            ));
+                    }
+                ).Where(m => m.Item2 != null).ToList();
+
+            // Version
+            source.AppendLine($"{bodyIndent}var version = reader.{(encodedVersion ? "ReadEncodedInt" : "ReadInt")}();");
+
+            if (version > 0)
+            {
+                var nextVersion = 0;
+
+                for (var i = 0; i < migrations.Length; i++)
+                {
+                    var migrationVersion = migrations[i].Version;
+                    if (migrationVersion == nextVersion)
+                    {
+                        nextVersion++;
                     }
 
-                    return (m, m.GetAttributes()
-                        .FirstOrDefault(
-                            attr => SymbolEqualityComparer.Default.Equals(
-                                attr.AttributeClass,
-                                compilation.GetTypeByMetadataName(SymbolMetadata.AFTER_DESERIALIZATION_ATTRIBUTE)
-                            )
-                        ));
+                    source.AppendLine();
+                    source.AppendLine($"{bodyIndent}if (version == {migrationVersion})");
+                    source.AppendLine($"{bodyIndent}{{");
+                    source.AppendLine($"{bodyIndent}    MigrateFrom(new V{migrationVersion}Content(reader, this));");
+                    if (markDirtyMethod != null)
+                    {
+                        source.AppendLine($"{bodyIndent}    {markDirtyMethod};");
+                    }
+                    source.GenerateAfterDeserialization($"{bodyIndent}    ", afterDeserialization);
+                    source.AppendLine($"{bodyIndent}    return;");
+                    source.AppendLine($"{bodyIndent}}}");
                 }
-            ).Where(m => m.Item2 != null).ToList();
 
-        // Version
-        source.AppendLine($"{bodyIndent}var version = reader.{(encodedVersion ? "ReadEncodedInt" : "ReadInt")}();");
-
-        if (version > 0)
-        {
-            var nextVersion = 0;
-
-            for (var i = 0; i < migrations.Length; i++)
-            {
-                var migrationVersion = migrations[i].Version;
-                if (migrationVersion == nextVersion)
+                if (nextVersion < version)
                 {
-                    nextVersion++;
+                    source.AppendLine();
+                    source.AppendLine($"{bodyIndent}if (version < SerializationVersion)");
+                    source.AppendLine($"{bodyIndent}{{");
+                    source.AppendLine($"{bodyIndent}    Deserialize(reader, version);");
+                    if (markDirtyMethod != null)
+                    {
+                        source.AppendLine($"{bodyIndent}    {markDirtyMethod};");
+                    }
+                    source.GenerateAfterDeserialization($"{bodyIndent}    ", afterDeserialization);
+                    source.AppendLine($"{bodyIndent}    return;");
+                    source.AppendLine($"{bodyIndent}}}");
                 }
-
-                source.AppendLine();
-                source.AppendLine($"{bodyIndent}if (version == {migrationVersion})");
-                source.AppendLine($"{bodyIndent}{{");
-                source.AppendLine($"{bodyIndent}    MigrateFrom(new V{migrationVersion}Content(reader, this));");
-                if (markDirtyMethod != null)
-                {
-                    source.AppendLine($"{bodyIndent}    {markDirtyMethod};");
-                }
-                source.GenerateAfterDeserialization($"{bodyIndent}    ", afterDeserialization);
-                source.AppendLine($"{bodyIndent}    return;");
-                source.AppendLine($"{bodyIndent}}}");
             }
 
-            if (nextVersion < version)
+            if (saveFlagMapping.Count > 0)
             {
                 source.AppendLine();
-                source.AppendLine($"{bodyIndent}if (version < SerializationVersion)");
-                source.AppendLine($"{bodyIndent}{{");
-                source.AppendLine($"{bodyIndent}    Deserialize(reader, version);");
-                if (markDirtyMethod != null)
+                // Read all save flag enums
+                for (var i = 0; i < saveFlagEnumCount; i++)
                 {
-                    source.AppendLine($"{bodyIndent}    {markDirtyMethod};");
+                    var enumName = i == 0 ? "SaveFlag" : $"SaveFlag{i + 1}";
+                    var varName = i == 0 ? "saveFlags" : $"saveFlags{i + 1}";
+                    source.AppendLine($"{bodyIndent}var {varName} = reader.ReadEnum<{enumName}>();");
                 }
-                source.GenerateAfterDeserialization($"{bodyIndent}    ", afterDeserialization);
-                source.AppendLine($"{bodyIndent}    return;");
-                source.AppendLine($"{bodyIndent}}}");
-            }
-        }
-
-        if (saveFlagMapping.Count > 0)
-        {
-            source.AppendLine();
-            // Read all save flag enums
-            for (var i = 0; i < saveFlagEnumCount; i++)
-            {
-                var enumName = i == 0 ? "SaveFlag" : $"SaveFlag{i + 1}";
-                var varName = i == 0 ? "saveFlags" : $"saveFlags{i + 1}";
-                source.AppendLine($"{bodyIndent}var {varName} = reader.ReadEnum<{enumName}>();");
-            }
-        }
-
-        for (var i = 0; i < fields.Length; i++)
-        {
-            var field = fields[i];
-
-            // Skip readonly fields - they cannot be assigned outside the constructor
-            if (field.IsReadOnly)
-            {
-                continue;
             }
 
-            var rule = SerializableMigrationRulesEngine.Rules[field.Rule];
-
-            if (serializableFieldSaveFlagMethodsDictionary.TryGetValue(
-                    field.Order,
-                    out var serializableFieldSaveFlagMethods
-                ) && saveFlagMapping.TryGetValue(field.Order, out var mapping))
+            for (var i = 0; i < fields.Length; i++)
             {
-                var enumName = mapping.EnumIndex == 0 ? "SaveFlag" : $"SaveFlag{mapping.EnumIndex + 1}";
-                var varName = mapping.EnumIndex == 0 ? "saveFlags" : $"saveFlags{mapping.EnumIndex + 1}";
+                var field = fields[i];
 
-                source.AppendLine();
-                // Special case
-                if (field.Type == "bool")
+                // Skip readonly fields - they cannot be assigned outside the constructor
+                if (field.IsReadOnly)
                 {
-                    source.AppendLine($"{bodyIndent}{field.FieldName} = ({varName} & {enumName}.{field.Name}) != 0;");
+                    continue;
+                }
+
+                var rule = SerializableMigrationRulesEngine.Rules[field.Rule];
+
+                if (serializableFieldSaveFlagMethodsDictionary.TryGetValue(
+                        field.Order,
+                        out var serializableFieldSaveFlagMethods
+                    ) && saveFlagMapping.TryGetValue(field.Order, out var mapping))
+                {
+                    var enumName = mapping.EnumIndex == 0 ? "SaveFlag" : $"SaveFlag{mapping.EnumIndex + 1}";
+                    var varName = mapping.EnumIndex == 0 ? "saveFlags" : $"saveFlags{mapping.EnumIndex + 1}";
+
+                    source.AppendLine();
+                    // Special case
+                    if (field.Type == "bool")
+                    {
+                        source.AppendLine($"{bodyIndent}{field.FieldName} = ({varName} & {enumName}.{field.Name}) != 0;");
+                    }
+                    else
+                    {
+                        source.AppendLine($"{bodyIndent}if (({varName} & {enumName}.{field.Name}) != 0)\n{bodyIndent}{{");
+                        rule.GenerateDeserializationMethod(
+                            source,
+                            innerIndent,
+                            compilation,
+                            field,
+                            parentReference
+                        );
+                        (rule as IPostDeserializeMethod)?.PostDeserializeMethod(
+                            source,
+                            innerIndent,
+                            field,
+                            compilation,
+                            classSymbol
+                        );
+
+                        if (serializableFieldSaveFlagMethods.GetFieldDefaultValue != null)
+                        {
+                            source.AppendLine($"{bodyIndent}}}\n{bodyIndent}else\n{bodyIndent}{{");
+                            source.AppendLine(
+                                $"{bodyIndent}    {field.FieldName} = {serializableFieldSaveFlagMethods.GetFieldDefaultValue.Name}();"
+                            );
+                        }
+
+                        source.AppendLine($"{bodyIndent}}}");
+                    }
                 }
                 else
                 {
-                    source.AppendLine($"{bodyIndent}if (({varName} & {enumName}.{field.Name}) != 0)\n{bodyIndent}{{");
+                    source.AppendLine();
                     rule.GenerateDeserializationMethod(
                         source,
-                        innerIndent,
+                        bodyIndent,
                         compilation,
                         field,
                         parentReference
                     );
                     (rule as IPostDeserializeMethod)?.PostDeserializeMethod(
                         source,
-                        innerIndent,
+                        bodyIndent,
                         field,
                         compilation,
                         classSymbol
                     );
-
-                    if (serializableFieldSaveFlagMethods.GetFieldDefaultValue != null)
-                    {
-                        source.AppendLine($"{bodyIndent}}}\n{bodyIndent}else\n{bodyIndent}{{");
-                        source.AppendLine(
-                            $"{bodyIndent}    {field.FieldName} = {serializableFieldSaveFlagMethods.GetFieldDefaultValue.Name}();"
-                        );
-                    }
-
-                    source.AppendLine($"{bodyIndent}}}");
                 }
             }
-            else
-            {
-                source.AppendLine();
-                rule.GenerateDeserializationMethod(
-                    source,
-                    bodyIndent,
-                    compilation,
-                    field,
-                    parentReference
-                );
-                (rule as IPostDeserializeMethod)?.PostDeserializeMethod(
-                    source,
-                    bodyIndent,
-                    field,
-                    compilation,
-                    classSymbol
-                );
-            }
+
+            source.GenerateAfterDeserialization($"{bodyIndent}", afterDeserialization);
+            source.GenerateMethodEnd(indent);
         }
 
-        source.GenerateAfterDeserialization($"{bodyIndent}", afterDeserialization);
-        source.GenerateMethodEnd(indent);
-    }
-
-    private static void GenerateAfterDeserialization(
-        this StringBuilder source, string indent, IList<(IMethodSymbol, AttributeData?)> afterDeserialization
-    )
-    {
-        foreach (var (method, attr) in afterDeserialization)
+        private void GenerateAfterDeserialization(
+            string indent, IList<(IMethodSymbol, AttributeData?)> afterDeserialization
+        )
         {
-            if ((bool)attr.ConstructorArguments[0].Value!)
+            foreach (var (method, attr) in afterDeserialization)
             {
-                source.AppendLine($"{indent}{method.Name}();");
-            }
-            else
-            {
-                source.AppendLine($"{indent}Timer.DelayCall({method.Name});");
+                if ((bool)attr.ConstructorArguments[0].Value!)
+                {
+                    source.AppendLine($"{indent}{method.Name}();");
+                }
+                else
+                {
+                    source.AppendLine($"{indent}Timer.DelayCall({method.Name});");
+                }
             }
         }
     }

--- a/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableEntityGeneration.SerializeMethod.cs
+++ b/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableEntityGeneration.SerializeMethod.cs
@@ -105,12 +105,14 @@ public static partial class SerializableEntityGeneration
                 continue;
             }
 
-            if (serializableFieldSaveFlagMethodsDictionary.ContainsKey(field.Order))
+            if (saveFlagMapping.TryGetValue(field.Order, out var mapping))
             {
                 // Special case
                 if (field.Type != "bool")
                 {
-                    source.AppendLine($"\n{bodyIndent}if ((saveFlags & SaveFlag.{field.Name}) != 0)\n{bodyIndent}{{");
+                    var enumName = mapping.EnumIndex == 0 ? "SaveFlag" : $"SaveFlag{mapping.EnumIndex + 1}";
+                    var varName = mapping.EnumIndex == 0 ? "saveFlags" : $"saveFlags{mapping.EnumIndex + 1}";
+                    source.AppendLine($"\n{bodyIndent}if (({varName} & {enumName}.{field.Name}) != 0)\n{bodyIndent}{{");
                     SerializableMigrationRulesEngine.Rules[field.Rule]
                         .GenerateSerializationMethod(
                             source,

--- a/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableEntityGeneration.SerializeMethod.cs
+++ b/ModernUO.Serialization.Generator/SerializableEntityGeneration/SerializableEntityGeneration.SerializeMethod.cs
@@ -29,7 +29,10 @@ public static partial class SerializableEntityGeneration
         bool isOverride,
         bool encodedVersion,
         ImmutableArray<SerializableProperty> fields,
-        SortedDictionary<int, SerializableFieldSaveFlagMethods> serializableFieldSaveFlagMethodsDictionary
+        SortedDictionary<int, SerializableFieldSaveFlagMethods> serializableFieldSaveFlagMethodsDictionary,
+        Dictionary<int, (int EnumIndex, int BitIndex)> saveFlagMapping,
+        bool saveFlagUseUlong,
+        int saveFlagEnumCount
     )
     {
         var genericWriterInterface = compilation.GetTypeByMetadataName(SymbolMetadata.GENERIC_WRITER_INTERFACE);
@@ -56,26 +59,52 @@ public static partial class SerializableEntityGeneration
         source.AppendLine($"{bodyIndent}writer.{(encodedVersion ? "WriteEncodedInt" : "Write")}(SerializationVersion);");
 
         // Let's collect the flags
-        if (serializableFieldSaveFlagMethodsDictionary.Count > 0)
+        if (saveFlagMapping.Count > 0)
         {
-            source.AppendLine($"\n{bodyIndent}var saveFlags = SaveFlag.None;");
+            // Initialize all save flag variables
+            for (var i = 0; i < saveFlagEnumCount; i++)
+            {
+                var enumName = i == 0 ? "SaveFlag" : $"SaveFlag{i + 1}";
+                var varName = i == 0 ? "saveFlags" : $"saveFlags{i + 1}";
+                source.AppendLine($"\n{bodyIndent}var {varName} = {enumName}.None;");
+            }
 
             foreach (var (order, saveFlagMethods) in serializableFieldSaveFlagMethodsDictionary)
             {
+                // Skip readonly fields
+                if (!saveFlagMapping.TryGetValue(order, out var mapping))
+                {
+                    continue;
+                }
+
                 source.AppendLine($"{bodyIndent}if ({saveFlagMethods.DetermineFieldShouldSerialize!.Name}())\n{bodyIndent}{{");
 
                 var propertyName = fields[order].Name;
-                source.AppendLine($"{innerIndent}saveFlags |= SaveFlag.{propertyName};");
+                var enumName = mapping.EnumIndex == 0 ? "SaveFlag" : $"SaveFlag{mapping.EnumIndex + 1}";
+                var varName = mapping.EnumIndex == 0 ? "saveFlags" : $"saveFlags{mapping.EnumIndex + 1}";
+                source.AppendLine($"{innerIndent}{varName} |= {enumName}.{propertyName};");
 
                 source.AppendLine($"{bodyIndent}}}");
             }
 
-            source.AppendLine($"{bodyIndent}writer.WriteEnum(saveFlags);");
+            // Write all save flags
+            for (var i = 0; i < saveFlagEnumCount; i++)
+            {
+                var varName = i == 0 ? "saveFlags" : $"saveFlags{i + 1}";
+                source.AppendLine($"{bodyIndent}writer.WriteEnum({varName});");
+            }
         }
 
         for (var i = 0; i < fields.Length; i++)
         {
             var field = fields[i];
+
+            // Skip readonly fields - they cannot be deserialized so we don't serialize them
+            if (field.IsReadOnly)
+            {
+                continue;
+            }
+
             if (serializableFieldSaveFlagMethodsDictionary.ContainsKey(field.Order))
             {
                 // Special case

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/DictionaryMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/DictionaryMigrationRule.cs
@@ -250,7 +250,7 @@ public class DictionaryMigrationRule : MigrationRule
             parentReference
         );
 
-        source.AppendLine($"{indent}    if (typeof({keyType}).IsValueType || {propertyKeyEntry} != null)");
+        source.AppendLine($"{indent}    if (typeof({keyType}).IsValueType || {propertyKeyEntry} != default)");
         source.AppendLine($"{indent}    {{");
         source.AppendLine($"{indent}        {propertyName}.Add({propertyKeyEntry}, {propertyValueEntry});");
         source.AppendLine($"{indent}    }}");

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/HashSetMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/HashSetMigrationRule.cs
@@ -184,7 +184,7 @@ public class HashSetMigrationRule : MigrationRule
             parentReference
         );
 
-        source.AppendLine($"{indent}    if (typeof({setElementType}).IsValueType || {propertyEntry} != null)");
+        source.AppendLine($"{indent}    if (typeof({setElementType}).IsValueType || {propertyEntry} != default)");
         source.AppendLine($"{indent}    {{");
         source.AppendLine($"{indent}        {propertyName}.Add({propertyEntry});");
         source.AppendLine($"{indent}    }}");

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/KeyValuePairMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/KeyValuePairMigrationRule.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
@@ -195,7 +194,7 @@ public class KeyValuePairMigrationRule : MigrationRule
         );
 
         source.AppendLine(
-            $"{indent}{propertyName} = new {SymbolMetadata.KEYVALUEPAIR_STRUCT}<{keyType}, {valueType}>(key, value);"
+            $"{indent}{propertyName} = new System.Collections.Generic.KeyValuePair<{keyType}, {valueType}>(key, value);"
         );
     }
 

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/ListMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/ListMigrationRule.cs
@@ -182,7 +182,11 @@ public class ListMigrationRule : MigrationRule
             serializableListElement,
             parentReference
         );
-        source.AppendLine($"{indent}    {propertyName}.Add({propertyEntry});");
+
+        source.AppendLine($"{indent}    if (typeof({listElementType}).IsValueType || {propertyEntry} != null)");
+        source.AppendLine($"{indent}    {{");
+        source.AppendLine($"{indent}        {propertyName}.Add({propertyEntry});");
+        source.AppendLine($"{indent}    }}");
 
         source.AppendLine($"{indent}}}");
     }
@@ -198,7 +202,7 @@ public class ListMigrationRule : MigrationRule
 
         var ruleArguments = property.RuleArguments;
         var shouldTidy = property.RuleArguments![0] == "@Tidy";
-        var index = shouldTidy || property.RuleArguments![0] == "" ? 1 : 0; // Skip the empty argyment
+        var index = shouldTidy || property.RuleArguments![0] == "" ? 1 : 0; // Skip the empty argument
         var canBeNull = property.RuleArguments[index] == "@CanBeNull";
 
         if (canBeNull)

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/ListMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/ListMigrationRule.cs
@@ -182,11 +182,7 @@ public class ListMigrationRule : MigrationRule
             serializableListElement,
             parentReference
         );
-
-        source.AppendLine($"{indent}    if (typeof({listElementType}).IsValueType || {propertyEntry} != null)");
-        source.AppendLine($"{indent}    {{");
-        source.AppendLine($"{indent}        {propertyName}.Add({propertyEntry});");
-        source.AppendLine($"{indent}    }}");
+        source.AppendLine($"{indent}    {propertyName}.Add({propertyEntry});");
 
         source.AppendLine($"{indent}}}");
     }

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/SortedSetMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/SortedSetMigrationRule.cs
@@ -164,9 +164,7 @@ public class SortedSetMigrationRule : MigrationRule
 
         source.AppendLine($"{indent}{setElementType} {propertyEntry};");
         source.AppendLine($"{indent}var {propertyCount} = reader.ReadEncodedInt();");
-
-        // Assume the sorted set is initialized in the constructor of the entity
-        // TODO: Add IComparer/IEnumerable support
+        source.AppendLine($"{indent}{propertyName} = new System.Collections.Generic.SortedSet<{setElementType}>();");
         source.AppendLine($"{indent}for (var {propertyIndex} = 0; {propertyIndex} < {propertyCount}; {propertyIndex}++)");
         source.AppendLine($"{indent}{{");
 
@@ -185,7 +183,11 @@ public class SortedSetMigrationRule : MigrationRule
             serializableSetElement,
             parentReference
         );
-        source.AppendLine($"{indent}    {propertyName}.Add({propertyEntry});");
+
+        source.AppendLine($"{indent}    if (typeof({setElementType}).IsValueType || {propertyEntry} != null)");
+        source.AppendLine($"{indent}    {{");
+        source.AppendLine($"{indent}        {propertyName}.Add({propertyEntry});");
+        source.AppendLine($"{indent}    }}");
 
         source.AppendLine($"{indent}}}");
     }

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/SortedSetMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/SortedSetMigrationRule.cs
@@ -203,7 +203,7 @@ public class SortedSetMigrationRule : MigrationRule
             parentReference
         );
 
-        source.AppendLine($"{indent}    if (typeof({setElementType}).IsValueType || {propertyEntry} != null)");
+        source.AppendLine($"{indent}    if (typeof({setElementType}).IsValueType || {propertyEntry} != default)");
         source.AppendLine($"{indent}    {{");
         source.AppendLine($"{indent}        {propertyName}.Add({propertyEntry});");
         source.AppendLine($"{indent}    }}");

--- a/ModernUO.Serialization.Generator/SerializableMigration/Rules/SortedSetMigrationRule.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/Rules/SortedSetMigrationRule.cs
@@ -53,9 +53,10 @@ public class SortedSetMigrationRule : MigrationRule
 
         var isTidy = attributes.Any(a => a.IsTidy(compilation));
         var canBeNull = attributes.Any(a => a.IsCanBeNull(compilation));
+        var hasComparer = attributes.TryGetSortedSetComparer(compilation, out var comparerExpression);
 
         var length = serializableSetType.RuleArguments?.Length ?? 0;
-        ruleArguments = new string[(isTidy ? 1 : 0) + (canBeNull ? 1 : 0) + 2 + length];
+        ruleArguments = new string[(isTidy ? 1 : 0) + (canBeNull ? 1 : 0) + (hasComparer ? 1 : 0) + 2 + length];
 
         var index = 0;
 
@@ -68,6 +69,12 @@ public class SortedSetMigrationRule : MigrationRule
         {
             ruleArguments[index++] = "@CanBeNull";
         }
+
+        if (hasComparer)
+        {
+            ruleArguments[index++] = $"@Comparer:{comparerExpression}";
+        }
+
         ruleArguments[index++] = setTypeSymbol.ToDisplayString();
         ruleArguments[index++] = serializableSetType.Rule;
 
@@ -104,7 +111,14 @@ public class SortedSetMigrationRule : MigrationRule
             index++;
         }
 
-        var setElementType = ruleArguments![index++];
+        string? comparerExpression = null;
+        if (ruleArguments![index].StartsWith("@Comparer:"))
+        {
+            comparerExpression = ruleArguments[index].Substring("@Comparer:".Length);
+            index++;
+        }
+
+        var setElementType = ruleArguments[index++];
         var setElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments[index++]];
         var setElementRuleArguments = new string[ruleArguments.Length - index];
 
@@ -124,7 +138,8 @@ public class SortedSetMigrationRule : MigrationRule
                 parentReference,
                 setElementType,
                 setElementRule,
-                setElementRuleArguments
+                setElementRuleArguments,
+                comparerExpression
             );
             source.AppendLine($"{indent}}}");
             source.AppendLine($"{indent}else");
@@ -142,7 +157,8 @@ public class SortedSetMigrationRule : MigrationRule
                 parentReference,
                 setElementType,
                 setElementRule,
-                setElementRuleArguments
+                setElementRuleArguments,
+                comparerExpression
             );
         }
     }
@@ -155,7 +171,8 @@ public class SortedSetMigrationRule : MigrationRule
         string parentReference,
         string setElementType,
         ISerializableMigrationRule setElementRule,
-        string[] setElementRuleArguments
+        string[] setElementRuleArguments,
+        string? comparerExpression = null
     )
     {
         var propertyIndex = $"{propertyName}Index";
@@ -164,7 +181,9 @@ public class SortedSetMigrationRule : MigrationRule
 
         source.AppendLine($"{indent}{setElementType} {propertyEntry};");
         source.AppendLine($"{indent}var {propertyCount} = reader.ReadEncodedInt();");
-        source.AppendLine($"{indent}{propertyName} = new System.Collections.Generic.SortedSet<{setElementType}>();");
+
+        var constructorArgs = comparerExpression != null ? comparerExpression : "";
+        source.AppendLine($"{indent}{propertyName} = new System.Collections.Generic.SortedSet<{setElementType}>({constructorArgs});");
         source.AppendLine($"{indent}for (var {propertyIndex} = 0; {propertyIndex} < {propertyCount}; {propertyIndex}++)");
         source.AppendLine($"{indent}{{");
 
@@ -211,7 +230,13 @@ public class SortedSetMigrationRule : MigrationRule
             index++;
         }
 
-        var setElementType = ruleArguments![index++];
+        // Skip @Comparer entry if present (comparer is only used during deserialization)
+        if (ruleArguments![index].StartsWith("@Comparer:"))
+        {
+            index++;
+        }
+
+        var setElementType = ruleArguments[index++];
         var setElementRule = SerializableMigrationRulesEngine.Rules[ruleArguments[index++]];
         var setElementRuleArguments = new string[ruleArguments.Length - index];
         Array.Copy(ruleArguments, index, setElementRuleArguments, 0, ruleArguments.Length - index);

--- a/ModernUO.Serialization.Generator/SerializableMigration/SerializableMigrationRulesEngine.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/SerializableMigrationRulesEngine.cs
@@ -13,7 +13,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
@@ -32,6 +31,7 @@ public static class SerializableMigrationRulesEngine
             new ListMigrationRule(),
             new ArrayMigrationRule(),
             new HashSetMigrationRule(),
+            new SortedSetMigrationRule(),
             new DictionaryMigrationRule(),
             new KeyValuePairMigrationRule(),
             new PrimitiveTypeMigrationRule(),

--- a/ModernUO.Serialization.Generator/SerializableMigration/SerializableMigrationSchema.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/SerializableMigrationSchema.cs
@@ -13,6 +13,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
+using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
@@ -21,17 +22,18 @@ namespace ModernUO.Serialization.Generator;
 
 public static class SerializableMigrationSchema
 {
-    private static JsonSerializerOptions defaultSerializerOptions;
-
-    public static JsonSerializerOptions GetJsonSerializerOptions() =>
-        defaultSerializerOptions ??= new JsonSerializerOptions
+    private static readonly Lazy<JsonSerializerOptions> _defaultSerializerOptions = new(
+        () => new JsonSerializerOptions
         {
             WriteIndented = true,
             AllowTrailingCommas = true,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             ReadCommentHandling = JsonCommentHandling.Skip,
             NewLine = "\n" // Force all json files to \n line endings
-        };
+        }
+    );
+
+    public static JsonSerializerOptions GetJsonSerializerOptions() => _defaultSerializerOptions.Value;
 
     // <ClassName>.v*.json
     public static readonly Regex MigrationFileRegex = new(@"^(\S+)\.[vV](\d+)\.json$", RegexOptions.Compiled);

--- a/ModernUO.Serialization.Generator/SerializableMigration/SerializableMigrationSchema.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/SerializableMigrationSchema.cs
@@ -35,8 +35,8 @@ public static class SerializableMigrationSchema
 
     public static JsonSerializerOptions GetJsonSerializerOptions() => _defaultSerializerOptions.Value;
 
-    // <ClassName>.v*.json
-    public static readonly Regex MigrationFileRegex = new(@"^(\S+)\.[vV](\d+)\.json$", RegexOptions.Compiled);
+    // <ClassName>.v*.json - supports generic arity notation like Foo`2.v1.json
+    public static readonly Regex MigrationFileRegex = new(@"^(\S+?(?:`\d+)?)\.[vV](\d+)\.json$", RegexOptions.Compiled);
 
     public static bool MatchMigrationFilename(string fileName, out string className, out int version)
     {

--- a/ModernUO.Serialization.Generator/SerializableMigration/SerializableProperty.cs
+++ b/ModernUO.Serialization.Generator/SerializableMigration/SerializableProperty.cs
@@ -39,4 +39,7 @@ public record SerializableProperty
 
     [JsonIgnore]
     public string? FieldName { get; init; }
+
+    [JsonIgnore]
+    public bool IsReadOnly { get; init; }
 }

--- a/ModernUO.Serialization.Generator/SourceGeneration/Helpers.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/Helpers.cs
@@ -13,11 +13,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -100,7 +98,7 @@ public static class Helpers
                 (t, token) =>
                 {
                     token.ThrowIfCancellationRequested();
-                    return (T)Convert.ChangeType(t, typeof(T));
+                    return t!;
                 }
             );
 

--- a/ModernUO.Serialization.Generator/SourceGeneration/Helpers.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/Helpers.cs
@@ -24,19 +24,22 @@ namespace ModernUO.Serialization.Generator;
 
 public static class Helpers
 {
-    public static bool ContainsInterface(this ITypeSymbol symbol, ISymbol interfaceSymbol) =>
-        symbol.Interfaces.Any(i => i.ConstructedFrom.Equals(interfaceSymbol, SymbolEqualityComparer.Default)) ||
-        symbol.AllInterfaces.Any(i => i.ConstructedFrom.Equals(interfaceSymbol, SymbolEqualityComparer.Default));
-
-    public static ImmutableArray<IMethodSymbol> GetAllMethods(this ITypeSymbol symbol, string name)
+    extension(ITypeSymbol symbol)
     {
-        var builder = ImmutableArray.CreateBuilder<IMethodSymbol>();
-        builder.AddRange(symbol.GetMembers(name).OfType<IMethodSymbol>());
-        if (symbol.BaseType is ITypeSymbol typeSymbol)
+        public bool ContainsInterface(ISymbol interfaceSymbol) =>
+            symbol.Interfaces.Any(i => i.ConstructedFrom.Equals(interfaceSymbol, SymbolEqualityComparer.Default)) ||
+            symbol.AllInterfaces.Any(i => i.ConstructedFrom.Equals(interfaceSymbol, SymbolEqualityComparer.Default));
+
+        public ImmutableArray<IMethodSymbol> GetAllMethods(string name)
         {
-            builder.AddRange(typeSymbol.GetAllMethods(name));
+            var builder = ImmutableArray.CreateBuilder<IMethodSymbol>();
+            builder.AddRange(symbol.GetMembers(name).OfType<IMethodSymbol>());
+            if (symbol.BaseType is ITypeSymbol typeSymbol)
+            {
+                builder.AddRange(typeSymbol.GetAllMethods(name));
+            }
+            return builder.ToImmutable();
         }
-        return builder.ToImmutable();
     }
 
     public static string ToFriendlyString(this Accessibility accessibility) => SyntaxFacts.GetText(accessibility);
@@ -78,9 +81,9 @@ public static class Helpers
             _                       => null
         };
 
-    public static bool IsPartial(this ClassDeclarationSyntax classDeclaration)
+    public static bool IsPartial(this TypeDeclarationSyntax typeDeclaration)
     {
-        foreach (var m in classDeclaration.Modifiers)
+        foreach (var m in typeDeclaration.Modifiers)
         {
             if (m.IsKind(SyntaxKind.PartialKeyword))
             {

--- a/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Arguments.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Arguments.cs
@@ -37,92 +37,95 @@ public static partial class SourceGeneration
         }
     }
 
-    public static void GenerateSignatureArguments(this StringBuilder source, ImmutableArray<(ITypeSymbol, string)> parameters)
+    extension(StringBuilder source)
     {
-        for (var i = 0; i < parameters.Length; i++)
+        public void GenerateSignatureArguments(ImmutableArray<(ITypeSymbol, string)> parameters)
         {
-            var (t, v) = parameters[i];
-            source.AppendFormat("{0} {1}", t.ToDisplayString(), v);
-            if (i < parameters.Length - 1)
+            for (var i = 0; i < parameters.Length; i++)
             {
-                source.Append(", ");
+                var (t, v) = parameters[i];
+                source.AppendFormat("{0} {1}", t.ToDisplayString(), v);
+                if (i < parameters.Length - 1)
+                {
+                    source.Append(", ");
+                }
             }
         }
-    }
 
-    public static void GenerateNamedArgument(this StringBuilder source, KeyValuePair<string, TypedConstant> namedArg)
-    {
-        source.AppendFormat("{0} = ", namedArg.Key);
-        source.GenerateTypedConstant(namedArg.Value);
-    }
-
-    public static void GenerateTypedConstants(this StringBuilder source, ImmutableArray<TypedConstant> args)
-    {
-        source.Append("new []{");
-        for (var i = 0; i < args.Length; i++)
+        public void GenerateNamedArgument(KeyValuePair<string, TypedConstant> namedArg)
         {
-            source.GenerateTypedConstant(args[i]);
-            if (i < args.Length - 1)
+            source.AppendFormat("{0} = ", namedArg.Key);
+            source.GenerateTypedConstant(namedArg.Value);
+        }
+
+        public void GenerateTypedConstants(ImmutableArray<TypedConstant> args)
+        {
+            source.Append("new []{");
+            for (var i = 0; i < args.Length; i++)
             {
-                source.Append(", ");
+                source.GenerateTypedConstant(args[i]);
+                if (i < args.Length - 1)
+                {
+                    source.Append(", ");
+                }
             }
-        }
-        source.Append('}');
-    }
-
-    public static void GenerateTypedConstant(this StringBuilder source, TypedConstant arg)
-    {
-        if (arg.IsNull)
-        {
-            source.Append("null");
-            return;
+            source.Append('}');
         }
 
-        switch (arg.Kind)
+        public void GenerateTypedConstant(TypedConstant arg)
         {
-            default:
-                {
-                    return;
-                }
-            case TypedConstantKind.Primitive:
-                {
+            if (arg.IsNull)
+            {
+                source.Append("null");
+                return;
+            }
 
-                    if (arg.Value is string str)
+            switch (arg.Kind)
+            {
+                default:
                     {
-                        source.AppendFormat("\"{0}\"", str);
+                        return;
                     }
-                    else if (arg.Value is bool bValue)
+                case TypedConstantKind.Primitive:
                     {
-                        source.Append(bValue ? "true" : "false");
+
+                        if (arg.Value is string str)
+                        {
+                            source.AppendFormat("\"{0}\"", str);
+                        }
+                        else if (arg.Value is bool bValue)
+                        {
+                            source.Append(bValue ? "true" : "false");
+                        }
+                        else
+                        {
+                            source.Append(arg.Value);
+                        }
+                        break;
                     }
-                    else
+                case TypedConstantKind.Enum:
                     {
-                        source.Append(arg.Value);
+                        if (arg.Type == null || arg.Value == null)
+                        {
+                            source.Append("null");
+                        }
+                        else
+                        {
+                            source.AppendFormat("({0}){1}", arg.Type.ToDisplayString(), arg.Value);
+                        }
+                        break;
                     }
-                    break;
-                }
-            case TypedConstantKind.Enum:
-                {
-                    if (arg.Type == null || arg.Value == null)
+                case TypedConstantKind.Type:
                     {
-                        source.Append("null");
+                        source.AppendFormat("typeof({0})", ((ITypeSymbol)arg.Value)?.Name);
+                        break;
                     }
-                    else
+                case TypedConstantKind.Array:
                     {
-                        source.AppendFormat("({0}){1}", arg.Type.ToDisplayString(), arg.Value);
+                        source.GenerateTypedConstants(arg.Values);
+                        break;
                     }
-                    break;
-                }
-            case TypedConstantKind.Type:
-                {
-                    source.AppendFormat("typeof({0})", ((ITypeSymbol)arg.Value)?.Name);
-                    break;
-                }
-            case TypedConstantKind.Array:
-                {
-                    source.GenerateTypedConstants(arg.Values);
-                    break;
-                }
+            }
         }
     }
 }

--- a/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Arguments.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Arguments.cs
@@ -13,7 +13,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;

--- a/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Attribute.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Attribute.cs
@@ -21,76 +21,78 @@ namespace ModernUO.Serialization.Generator;
 
 public static partial class SourceGeneration
 {
-    public static void GenerateAttribute(
-        this StringBuilder source,
-        string indent,
-        string attrClassName,
-        ImmutableArray<TypedConstant> args
-    )
+    extension(StringBuilder source)
     {
-        source.Append($"{indent}[{attrClassName}");
-        var hasArgs = args.Length > 0;
-
-        if (hasArgs)
+        public void GenerateAttribute(
+            string indent,
+            string attrClassName,
+            ImmutableArray<TypedConstant> args
+        )
         {
-            source.Append("(");
-        }
+            source.Append($"{indent}[{attrClassName}");
+            var hasArgs = args.Length > 0;
 
-        for (var i = 0; i < args.Length; i++)
-        {
-            var arg = args[i];
-            source.GenerateTypedConstant(arg);
-            if (i < args.Length - 1)
+            if (hasArgs)
             {
-                source.Append(", ");
+                source.Append("(");
             }
-        }
 
-        if (hasArgs)
-        {
-            source.Append(")");
-        }
-
-        source.AppendLine("]");
-    }
-
-    public static void GenerateAttribute(this StringBuilder source, AttributeData attr)
-    {
-        source.Append($"        [{attr.AttributeClass?.Name}");
-        var ctorArgs = attr.ConstructorArguments;
-        var namedArgs = attr.NamedArguments;
-        var hasArgs = ctorArgs.Length + namedArgs.Length > 0;
-
-        if (hasArgs)
-        {
-            source.Append("(");
-        }
-
-        for (var i = 0; i < ctorArgs.Length; i++)
-        {
-            var arg = ctorArgs[i];
-            source.GenerateTypedConstant(arg);
-            if (i < ctorArgs.Length - 1)
+            for (var i = 0; i < args.Length; i++)
             {
-                source.Append(", ");
+                var arg = args[i];
+                source.GenerateTypedConstant(arg);
+                if (i < args.Length - 1)
+                {
+                    source.Append(", ");
+                }
             }
-        }
 
-        for (var i = 0; i < namedArgs.Length; i++)
-        {
-            var arg = namedArgs[i];
-            source.GenerateNamedArgument(arg);
-            if (i < namedArgs.Length - 1)
+            if (hasArgs)
             {
-                source.Append(", ");
+                source.Append(")");
             }
+
+            source.AppendLine("]");
         }
 
-        if (hasArgs)
+        public void GenerateAttribute(AttributeData attr)
         {
-            source.Append(")");
-        }
+            source.Append($"        [{attr.AttributeClass?.Name}");
+            var ctorArgs = attr.ConstructorArguments;
+            var namedArgs = attr.NamedArguments;
+            var hasArgs = ctorArgs.Length + namedArgs.Length > 0;
 
-        source.AppendLine("]");
+            if (hasArgs)
+            {
+                source.Append("(");
+            }
+
+            for (var i = 0; i < ctorArgs.Length; i++)
+            {
+                var arg = ctorArgs[i];
+                source.GenerateTypedConstant(arg);
+                if (i < ctorArgs.Length - 1)
+                {
+                    source.Append(", ");
+                }
+            }
+
+            for (var i = 0; i < namedArgs.Length; i++)
+            {
+                var arg = namedArgs[i];
+                source.GenerateNamedArgument(arg);
+                if (i < namedArgs.Length - 1)
+                {
+                    source.Append(", ");
+                }
+            }
+
+            if (hasArgs)
+            {
+                source.Append(")");
+            }
+
+            source.AppendLine("]");
+        }
     }
 }

--- a/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Class.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Class.cs
@@ -14,41 +14,135 @@
  *************************************************************************/
 
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ModernUO.Serialization.Generator;
 
 public static partial class SourceGeneration
 {
-    public static void GenerateClassStart(
-        this StringBuilder source,
-        INamedTypeSymbol classSymbol,
-        string indent,
-        ImmutableArray<ITypeSymbol> interfaces,
-        bool isPartial = true
-    )
-    {
-        var accessor = classSymbol.DeclaredAccessibility;
-        source.Append($"{indent}{accessor.ToFriendlyString()} {(isPartial ? "partial " : "")}class {classSymbol.Name}");
-        if (!interfaces.IsEmpty)
+    public static string GetTypeKeyword(this TypeDeclarationSyntax typeNode) =>
+        typeNode switch
         {
-            source.Append(" : ");
-            for (var i = 0; i < interfaces.Length; i++)
+            RecordDeclarationSyntax { ClassOrStructKeyword.RawKind: not 0 } => "record struct",
+            RecordDeclarationSyntax => "record",
+            StructDeclarationSyntax => "struct",
+            _ => "class"
+        };
+
+    extension(INamedTypeSymbol classSymbol)
+    {
+        public string GetClassNameWithTypeParameters()
+        {
+            if (!classSymbol.IsGenericType)
             {
-                source.Append(interfaces[i].ToDisplayString());
-                if (i < interfaces.Length - 1)
-                {
-                    source.Append(", ");
-                }
+                return classSymbol.Name;
             }
+
+            var typeParams = string.Join(", ", classSymbol.TypeParameters.Select(tp => tp.Name));
+            return $"{classSymbol.Name}<{typeParams}>";
         }
 
-        source.AppendLine($"\n{indent}{{");
+        public string GetWhereClausesForTypeParameters()
+        {
+            if (!classSymbol.IsGenericType)
+            {
+                return "";
+            }
+
+            var whereClauses = new StringBuilder();
+            foreach (var typeParam in classSymbol.TypeParameters)
+            {
+                var constraints = new System.Collections.Generic.List<string>();
+
+                if (typeParam.HasReferenceTypeConstraint)
+                {
+                    constraints.Add("class");
+                }
+                else if (typeParam.HasValueTypeConstraint)
+                {
+                    constraints.Add("struct");
+                }
+                else if (typeParam.HasUnmanagedTypeConstraint)
+                {
+                    constraints.Add("unmanaged");
+                }
+
+                if (typeParam.HasNotNullConstraint)
+                {
+                    constraints.Add("notnull");
+                }
+
+                foreach (var constraintType in typeParam.ConstraintTypes)
+                {
+                    constraints.Add(constraintType.ToDisplayString());
+                }
+
+                if (typeParam.HasConstructorConstraint)
+                {
+                    constraints.Add("new()");
+                }
+
+                if (constraints.Count > 0)
+                {
+                    whereClauses.Append($" where {typeParam.Name} : {string.Join(", ", constraints)}");
+                }
+            }
+
+            return whereClauses.ToString();
+        }
+
+        public string GetGenericArityName()
+        {
+            if (!classSymbol.IsGenericType)
+            {
+                return classSymbol.ToDisplayString();
+            }
+
+            // Get the full namespace path and class name with arity notation
+            var containingNamespace = classSymbol.ContainingNamespace?.ToDisplayString();
+            var arityName = $"{classSymbol.Name}`{classSymbol.Arity}";
+
+            return string.IsNullOrEmpty(containingNamespace) ? arityName : $"{containingNamespace}.{arityName}";
+        }
     }
 
-    public static void GenerateClassEnd(this StringBuilder source, string indent)
+    extension(StringBuilder source)
     {
-        source.AppendLine($"{indent}}}");
+        public void GenerateClassStart(
+            INamedTypeSymbol classSymbol,
+            string indent,
+            ImmutableArray<ITypeSymbol> interfaces,
+            bool isPartial = true,
+            string typeKeyword = "class"
+        )
+        {
+            var accessor = classSymbol.DeclaredAccessibility;
+            var className = classSymbol.GetClassNameWithTypeParameters();
+            var whereClauses = classSymbol.GetWhereClausesForTypeParameters();
+
+            source.Append($"{indent}{accessor.ToFriendlyString()} {(isPartial ? "partial " : "")}{typeKeyword} {className}");
+            if (!interfaces.IsEmpty)
+            {
+                source.Append(" : ");
+                for (var i = 0; i < interfaces.Length; i++)
+                {
+                    source.Append(interfaces[i].ToDisplayString());
+                    if (i < interfaces.Length - 1)
+                    {
+                        source.Append(", ");
+                    }
+                }
+            }
+
+            source.AppendLine($"{whereClauses}\n{indent}{{");
+        }
+
+        public void GenerateClassEnd(string indent)
+        {
+            source.AppendLine($"{indent}}}");
+        }
     }
 }

--- a/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Enum.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Enum.cs
@@ -25,20 +25,30 @@ public static partial class SourceGeneration
         string enumName,
         string indent,
         bool useFlags,
-        Accessibility accessor = Accessibility.Public
+        Accessibility accessor = Accessibility.Public,
+        string? underlyingType = null
     )
     {
         if (useFlags)
         {
             source.AppendLine($"{indent}[System.Flags]");
         }
-        source.AppendLine($"{indent}{accessor.ToFriendlyString()} enum {enumName}\n{indent}{{");
+
+        var typeSpecifier = underlyingType != null ? $" : {underlyingType}" : "";
+        source.AppendLine($"{indent}{accessor.ToFriendlyString()} enum {enumName}{typeSpecifier}\n{indent}{{");
     }
 
     public static void GenerateEnumValue(this StringBuilder source, string indent, bool isFlag, string name, int value)
     {
         var number = value < 0 ? 0 : 1 << value;
         var valueStr = isFlag ? $"0x{number:X8}" : value.ToString();
+        source.AppendLine($"{indent}{name} = {valueStr},");
+    }
+
+    public static void GenerateEnumValueLong(this StringBuilder source, string indent, bool isFlag, string name, int value)
+    {
+        var number = value < 0 ? 0UL : 1UL << value;
+        var valueStr = isFlag ? $"0x{number:X16}" : value.ToString();
         source.AppendLine($"{indent}{name} = {valueStr},");
     }
 

--- a/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Enum.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Enum.cs
@@ -20,40 +20,42 @@ namespace ModernUO.Serialization.Generator;
 
 public static partial class SourceGeneration
 {
-    public static void GenerateEnumStart(
-        this StringBuilder source,
-        string enumName,
-        string indent,
-        bool useFlags,
-        Accessibility accessor = Accessibility.Public,
-        string? underlyingType = null
-    )
+    extension(StringBuilder source)
     {
-        if (useFlags)
+        public void GenerateEnumStart(
+            string enumName,
+            string indent,
+            bool useFlags,
+            Accessibility accessor = Accessibility.Public,
+            string underlyingType = null
+        )
         {
-            source.AppendLine($"{indent}[System.Flags]");
+            if (useFlags)
+            {
+                source.AppendLine($"{indent}[System.Flags]");
+            }
+
+            var typeSpecifier = underlyingType != null ? $" : {underlyingType}" : "";
+            source.AppendLine($"{indent}{accessor.ToFriendlyString()} enum {enumName}{typeSpecifier}\n{indent}{{");
         }
 
-        var typeSpecifier = underlyingType != null ? $" : {underlyingType}" : "";
-        source.AppendLine($"{indent}{accessor.ToFriendlyString()} enum {enumName}{typeSpecifier}\n{indent}{{");
-    }
+        public void GenerateEnumValue(string indent, bool isFlag, string name, int value)
+        {
+            var number = value < 0 ? 0 : 1 << value;
+            var valueStr = isFlag ? $"0x{number:X8}" : value.ToString();
+            source.AppendLine($"{indent}{name} = {valueStr},");
+        }
 
-    public static void GenerateEnumValue(this StringBuilder source, string indent, bool isFlag, string name, int value)
-    {
-        var number = value < 0 ? 0 : 1 << value;
-        var valueStr = isFlag ? $"0x{number:X8}" : value.ToString();
-        source.AppendLine($"{indent}{name} = {valueStr},");
-    }
+        public void GenerateEnumValueLong(string indent, bool isFlag, string name, int value)
+        {
+            var number = value < 0 ? 0UL : 1UL << value;
+            var valueStr = isFlag ? $"0x{number:X16}" : value.ToString();
+            source.AppendLine($"{indent}{name} = {valueStr},");
+        }
 
-    public static void GenerateEnumValueLong(this StringBuilder source, string indent, bool isFlag, string name, int value)
-    {
-        var number = value < 0 ? 0UL : 1UL << value;
-        var valueStr = isFlag ? $"0x{number:X16}" : value.ToString();
-        source.AppendLine($"{indent}{name} = {valueStr},");
-    }
-
-    public static void GenerateEnumEnd(this StringBuilder source, string indent)
-    {
-        source.AppendLine($"{indent}}}");
+        public void GenerateEnumEnd(string indent)
+        {
+            source.AppendLine($"{indent}}}");
+        }
     }
 }

--- a/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Field.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Field.cs
@@ -24,7 +24,10 @@ public static partial class SourceGeneration
     public static string GetFieldName(this string propertyName)
     {
         var humanized = Utility.RunAsEnglish(propertyName.Humanize);
-        var camelized = Utility.RunAsEnglish(humanized.Camelize);
+        // Camelize may not remove spaces introduced by Humanize in Humanizer 3.x
+        // Remove any spaces since C# identifiers cannot contain spaces.
+        // See: https://github.com/Humanizr/Humanizer/issues/1656
+        var camelized = Utility.RunAsEnglish(humanized.Camelize).Replace(" ", "");
         return $"_{camelized}";
     }
 

--- a/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Method.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Method.cs
@@ -21,41 +21,44 @@ namespace ModernUO.Serialization.Generator;
 
 public static partial class SourceGeneration
 {
-    public static void GenerateMethodStart(
-        this StringBuilder source, string indent, string methodName, Accessibility accessors, bool isOverride,
-        string returnType, ImmutableArray<(ITypeSymbol, string)> parameters
-    )
+    extension(StringBuilder source)
     {
-        source.Append($"{indent}{accessors.ToFriendlyString()}{(isOverride ? " override" : " virtual")} {returnType} {methodName}(");
-        source.GenerateSignatureArguments(parameters);
-        source.AppendLine($")\n{indent}{{");
-    }
-
-    public static void GenerateMethodEnd(this StringBuilder source, string indent) => source.AppendLine($"{indent}}}");
-
-    public static void GenerateConstructorStart(
-        this StringBuilder source, string indent, string className, Accessibility accessors, ImmutableArray<(ITypeSymbol, string)> parameters,
-        ImmutableArray<string>? baseParameters, bool isOverload = false
-    )
-    {
-        source.Append($"{indent}{accessors.ToFriendlyString()} {className}(");
-        source.GenerateSignatureArguments(parameters);
-        source.Append(')');
-        if ((baseParameters?.Length ?? 0) > 0)
+        public void GenerateMethodStart(
+            string indent, string methodName, Accessibility accessors, bool isOverride,
+            string returnType, ImmutableArray<(ITypeSymbol, string)> parameters
+        )
         {
-            source.AppendFormat(" : {0}(", isOverload ? "this" : "base");
-            var baseParametersValue = baseParameters.Value;
-            for (int i = 0; i < baseParametersValue.Length; i++)
-            {
-                source.Append(baseParametersValue[i]);
-                if (i < baseParametersValue.Length - 1)
-                {
-                    source.Append(',');
-                }
-            }
-            source.Append(')');
+            source.Append($"{indent}{accessors.ToFriendlyString()}{(isOverride ? " override" : " virtual")} {returnType} {methodName}(");
+            source.GenerateSignatureArguments(parameters);
+            source.AppendLine($")\n{indent}{{");
         }
 
-        source.AppendLine($"\n{indent}{{");
+        public void GenerateMethodEnd(string indent) => source.AppendLine($"{indent}}}");
+
+        public void GenerateConstructorStart(
+            string indent, string className, Accessibility accessors, ImmutableArray<(ITypeSymbol, string)> parameters,
+            ImmutableArray<string>? baseParameters, bool isOverload = false
+        )
+        {
+            source.Append($"{indent}{accessors.ToFriendlyString()} {className}(");
+            source.GenerateSignatureArguments(parameters);
+            source.Append(')');
+            if ((baseParameters?.Length ?? 0) > 0)
+            {
+                source.AppendFormat(" : {0}(", isOverload ? "this" : "base");
+                var baseParametersValue = baseParameters.Value;
+                for (int i = 0; i < baseParametersValue.Length; i++)
+                {
+                    source.Append(baseParametersValue[i]);
+                    if (i < baseParametersValue.Length - 1)
+                    {
+                        source.Append(',');
+                    }
+                }
+                source.Append(')');
+            }
+
+            source.AppendLine($"\n{indent}{{");
+        }
     }
 }

--- a/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Namespace.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Namespace.cs
@@ -19,16 +19,19 @@ namespace ModernUO.Serialization.Generator;
 
 public static partial class SourceGeneration
 {
-    public static void GenerateNamespaceStart(this StringBuilder source, string namespaceName)
+    extension(StringBuilder source)
     {
-        source.AppendLine($$"""
-                            namespace {{namespaceName}}
-                            {
-                            """);
-    }
+        public void GenerateNamespaceStart(string namespaceName)
+        {
+            source.AppendLine($$"""
+                                namespace {{namespaceName}}
+                                {
+                                """);
+        }
 
-    public static void GenerateNamespaceEnd(this StringBuilder source)
-    {
-        source.AppendLine("}");
+        public void GenerateNamespaceEnd()
+        {
+            source.AppendLine("}");
+        }
     }
 }

--- a/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Property.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Property.cs
@@ -35,7 +35,11 @@ public static partial class SourceGeneration
             propertyName = propertyName.Substring(1);
         }
 
-        return Utility.RunAsEnglish(propertyName.Dehumanize);
+        // Dehumanize converts "some text" to "SomeText", but in Humanizer 3.x it may insert
+        // spaces before numbers (e.g., "slayer2" becomes "Slayer 2"). Remove any spaces since
+        // C# identifiers cannot contain spaces.
+        // See: https://github.com/Humanizr/Humanizer/issues/1656
+        return Utility.RunAsEnglish(propertyName.Dehumanize).Replace(" ", "");
     }
 
     extension(StringBuilder source)

--- a/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Property.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SourceGeneration.Property.cs
@@ -38,104 +38,102 @@ public static partial class SourceGeneration
         return Utility.RunAsEnglish(propertyName.Dehumanize);
     }
 
-    public static void GeneratePropertyStart(
-        this StringBuilder source,
-        string indent,
-        Accessibility accessors,
-        bool isVirtual,
-        IFieldSymbol fieldSymbol
-    )
+    extension(StringBuilder source)
     {
-        var propertyName = fieldSymbol.Name.GetPropertyName();
-        var virt = isVirtual ? "virtual " : "";
-
-        source.AppendLine($"{indent}{accessors.ToFriendlyString()} {virt}{fieldSymbol.Type} {propertyName}");
-        source.AppendLine($"{indent}{{");
-    }
-
-    public static void GenerateAutoProperty(
-        this StringBuilder source,
-        Accessibility accessors,
-        string type,
-        string propertyName,
-        Accessibility? getAccessor,
-        Accessibility? setAccessor,
-        string indent,
-        bool useInit = false,
-        string defaultValue = null,
-        bool isOverride = false
-    )
-    {
-        if (getAccessor == null && setAccessor == null)
+        public void GeneratePropertyStart(
+            string indent,
+            Accessibility accessors,
+            bool isVirtual,
+            IFieldSymbol fieldSymbol
+        )
         {
-            throw new ArgumentNullException($"Must specify a {nameof(getAccessor)} or {nameof(setAccessor)} parameter");
+            var propertyName = fieldSymbol.Name.GetPropertyName();
+            var virt = isVirtual ? "virtual " : "";
+
+            source.AppendLine($"{indent}{accessors.ToFriendlyString()} {virt}{fieldSymbol.Type} {propertyName}");
+            source.AppendLine($"{indent}{{");
         }
 
-        var getter = getAccessor == null ?
-            "" :
-            $"{(getAccessor != Accessibility.NotApplicable ? $"{getAccessor.Value.ToFriendlyString()} " : "")}get;";
-
-        var getterSpace = getAccessor != null ? " " : "";
-        var setOrInit = useInit ? "init;" : "set;";
-
-        var setterAccessor = setAccessor is null or Accessibility.NotApplicable
-            ? ""
-            : $"{setAccessor.Value.ToFriendlyString() ?? ""} ";
-
-        var setter = setAccessor == null ? "" : $"{getterSpace}{setterAccessor}{setOrInit}";
-
-        var propertyAccessor = accessors == Accessibility.NotApplicable ? "" : $"{accessors.ToFriendlyString()} ";
-        var printOverride = isOverride ? "override " : "";
-        var printDefaultValue = defaultValue != null ? $"{(setAccessor != null ? " =" : "")} {defaultValue};" : "";
-        var printGetterSetter = setAccessor == null ? "=>" : $"{{ {getter}{setter} }}";
-
-        source.AppendLine($"{indent}{propertyAccessor}{printOverride}{type} {propertyName} {printGetterSetter}{printDefaultValue}");
-    }
-
-    public static void GeneratePropertyEnd(this StringBuilder source, string indent) => source.AppendLine($"{indent}}}");
-
-    public static void GeneratePropertyGetterReturnsField(
-        this StringBuilder source,
-        string indent,
-        IFieldSymbol fieldSymbol,
-        Accessibility Accessibility
-    )
-    {
-        var accessor = Accessibility != Accessibility.NotApplicable ? $"{Accessibility.ToFriendlyString()} " : "";
-        source.AppendLine($"{indent}{accessor}get => {fieldSymbol.Name};");
-    }
-
-    public static void GeneratePropertyGetterStart(
-        this StringBuilder source,
-        string indent,
-        bool useExpression,
-        Accessibility Accessibility
-    )
-    {
-        var accessor = Accessibility != Accessibility.NotApplicable ? $"{Accessibility.ToFriendlyString()} " : "";
-        var expression = useExpression ? " => " : $"\n{indent}{{";
-        source.AppendLine($"{indent}{accessor}get{expression}");
-    }
-
-    public static void GeneratePropertyGetSetEnd(this StringBuilder source, string indent, bool useExpression)
-    {
-        if (!useExpression)
+        public void GenerateAutoProperty(
+            Accessibility accessors,
+            string type,
+            string propertyName,
+            Accessibility? getAccessor,
+            Accessibility? setAccessor,
+            string indent,
+            bool useInit = false,
+            string defaultValue = null,
+            bool isOverride = false
+        )
         {
-            source.AppendLine($"{indent}}}");
-        }
-    }
+            if (getAccessor == null && setAccessor == null)
+            {
+                throw new ArgumentNullException($"Must specify a {nameof(getAccessor)} or {nameof(setAccessor)} parameter");
+            }
 
-    public static void GeneratePropertySetterStart(
-        this StringBuilder source,
-        string indent,
-        bool useExpression,
-        Accessibility Accessibility,
-        bool useInit = false
-    )
-    {
-        var init = useInit ? "init" : "set";
-        var expression = useExpression ? " => " : $"\n{indent}{{";
-        var accessor = Accessibility != Accessibility.NotApplicable ? $"{Accessibility.ToFriendlyString()} " : "";
-        source.AppendLine($"{indent}{accessor}{init}{expression}");
+            var getter = getAccessor == null ?
+                "" :
+                $"{(getAccessor != Accessibility.NotApplicable ? $"{getAccessor.Value.ToFriendlyString()} " : "")}get;";
+
+            var getterSpace = getAccessor != null ? " " : "";
+            var setOrInit = useInit ? "init;" : "set;";
+
+            var setterAccessor = setAccessor is null or Accessibility.NotApplicable
+                ? ""
+                : $"{setAccessor.Value.ToFriendlyString() ?? ""} ";
+
+            var setter = setAccessor == null ? "" : $"{getterSpace}{setterAccessor}{setOrInit}";
+
+            var propertyAccessor = accessors == Accessibility.NotApplicable ? "" : $"{accessors.ToFriendlyString()} ";
+            var printOverride = isOverride ? "override " : "";
+            var printDefaultValue = defaultValue != null ? $"{(setAccessor != null ? " =" : "")} {defaultValue};" : "";
+            var printGetterSetter = setAccessor == null ? "=>" : $"{{ {getter}{setter} }}";
+
+            source.AppendLine($"{indent}{propertyAccessor}{printOverride}{type} {propertyName} {printGetterSetter}{printDefaultValue}");
+        }
+
+        public void GeneratePropertyEnd(string indent) => source.AppendLine($"{indent}}}");
+
+        public void GeneratePropertyGetterReturnsField(
+            string indent,
+            IFieldSymbol fieldSymbol,
+            Accessibility Accessibility
+        )
+        {
+            var accessor = Accessibility != Accessibility.NotApplicable ? $"{Accessibility.ToFriendlyString()} " : "";
+            source.AppendLine($"{indent}{accessor}get => {fieldSymbol.Name};");
+        }
+
+        public void GeneratePropertyGetterStart(
+            string indent,
+            bool useExpression,
+            Accessibility Accessibility
+        )
+        {
+            var accessor = Accessibility != Accessibility.NotApplicable ? $"{Accessibility.ToFriendlyString()} " : "";
+            var expression = useExpression ? " => " : $"\n{indent}{{";
+            source.AppendLine($"{indent}{accessor}get{expression}");
+        }
+
+        public void GeneratePropertyGetSetEnd(string indent, bool useExpression)
+        {
+            if (!useExpression)
+            {
+                source.AppendLine($"{indent}}}");
+            }
+        }
+
+        public void GeneratePropertySetterStart(
+            string indent,
+            bool useExpression,
+            Accessibility Accessibility,
+            bool useInit = false
+        )
+        {
+            var init = useInit ? "init" : "set";
+            var expression = useExpression ? " => " : $"\n{indent}{{";
+            var accessor = Accessibility != Accessibility.NotApplicable ? $"{Accessibility.ToFriendlyString()} " : "";
+            source.AppendLine($"{indent}{accessor}{init}{expression}");
+        }
     }
 }

--- a/ModernUO.Serialization.Generator/SourceGeneration/SymbolMetadata/SymbolMetadata.Builtin.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SymbolMetadata/SymbolMetadata.Builtin.cs
@@ -34,65 +34,68 @@ public static partial class SymbolMetadata
     public const string GUID_STRUCT = "System.Guid";
     public const string TYPE_CLASS = "System.Type";
 
-    public static bool IsGuid(this ISymbol symbol, Compilation compilation) =>
-        symbol.Equals(
-            compilation.GetTypeByMetadataName(GUID_STRUCT),
-            SymbolEqualityComparer.Default
-        );
+    extension(ISymbol symbol)
+    {
+        public bool IsGuid(Compilation compilation) =>
+            symbol.Equals(
+                compilation.GetTypeByMetadataName(GUID_STRUCT),
+                SymbolEqualityComparer.Default
+            );
 
-    public static bool IsTimeSpan(this ISymbol symbol, Compilation compilation) =>
-        symbol.Equals(
-            compilation.GetTypeByMetadataName(TIMESPAN_STRUCT),
-            SymbolEqualityComparer.Default
-        );
+        public bool IsTimeSpan(Compilation compilation) =>
+            symbol.Equals(
+                compilation.GetTypeByMetadataName(TIMESPAN_STRUCT),
+                SymbolEqualityComparer.Default
+            );
 
-    public static bool IsIpAddress(this ISymbol symbol, Compilation compilation) =>
-        symbol.Equals(
-            compilation.GetTypeByMetadataName(IPADDRESS_CLASS),
-            SymbolEqualityComparer.Default
-        );
+        public bool IsIpAddress(Compilation compilation) =>
+            symbol.Equals(
+                compilation.GetTypeByMetadataName(IPADDRESS_CLASS),
+                SymbolEqualityComparer.Default
+            );
 
-    public static bool IsKeyValuePair(this ISymbol symbol, Compilation compilation) =>
-        (symbol as INamedTypeSymbol)?.ConstructedFrom.Equals(
-            compilation.GetTypeByMetadataName(KEYVALUEPAIR_STRUCT),
-            SymbolEqualityComparer.Default
-        ) == true;
+        public bool IsKeyValuePair(Compilation compilation) =>
+            (symbol as INamedTypeSymbol)?.ConstructedFrom.Equals(
+                compilation.GetTypeByMetadataName(KEYVALUEPAIR_STRUCT),
+                SymbolEqualityComparer.Default
+            ) == true;
 
-    public static bool IsDictionary(this ISymbol symbol, Compilation compilation) =>
-        (symbol as INamedTypeSymbol)?.ConstructedFrom.Equals(
-            compilation.GetTypeByMetadataName(DICTIONARY_CLASS),
-            SymbolEqualityComparer.Default
-        ) == true;
+        public bool IsDictionary(Compilation compilation) =>
+            (symbol as INamedTypeSymbol)?.ConstructedFrom.Equals(
+                compilation.GetTypeByMetadataName(DICTIONARY_CLASS),
+                SymbolEqualityComparer.Default
+            ) == true;
 
-    public static bool IsDictionaryInterface(this ISymbol symbol, Compilation compilation) =>
-        (symbol as INamedTypeSymbol)?.ContainsInterface(compilation.GetTypeByMetadataName(DICTIONARY_INTERFACE)) ?? false;
+        public bool IsDictionaryInterface(Compilation compilation) =>
+            (symbol as INamedTypeSymbol)?.ContainsInterface(compilation.GetTypeByMetadataName(DICTIONARY_INTERFACE)) ?? false;
 
-    public static bool IsHashSet(this ISymbol symbol, Compilation compilation) =>
-        (symbol as INamedTypeSymbol)?.ConstructedFrom.Equals(
-            compilation.GetTypeByMetadataName(HASHSET_CLASS),
-            SymbolEqualityComparer.Default
-        ) == true;
+        public bool IsHashSet(Compilation compilation) =>
+            (symbol as INamedTypeSymbol)?.ConstructedFrom.Equals(
+                compilation.GetTypeByMetadataName(HASHSET_CLASS),
+                SymbolEqualityComparer.Default
+            ) == true;
 
-    public static bool IsSortedSet(this ISymbol symbol, Compilation compilation) =>
-        (symbol as INamedTypeSymbol)?.ConstructedFrom.Equals(
-            compilation.GetTypeByMetadataName(SORTEDSET_CLASS),
-            SymbolEqualityComparer.Default
-        ) == true;
+        public bool IsSortedSet(Compilation compilation) =>
+            (symbol as INamedTypeSymbol)?.ConstructedFrom.Equals(
+                compilation.GetTypeByMetadataName(SORTEDSET_CLASS),
+                SymbolEqualityComparer.Default
+            ) == true;
 
-    public static bool IsSet(this ISymbol symbol, Compilation compilation) =>
-        (symbol as INamedTypeSymbol)?.ContainsInterface(compilation.GetTypeByMetadataName(SET_INTERFACE)) ?? false;
+        public bool IsSet(Compilation compilation) =>
+            (symbol as INamedTypeSymbol)?.ContainsInterface(compilation.GetTypeByMetadataName(SET_INTERFACE)) ?? false;
 
-    public static bool IsCollection(this ISymbol symbol, Compilation compilation) =>
-        (symbol as INamedTypeSymbol)?.ContainsInterface(compilation.GetTypeByMetadataName(COLLECTION_INTERFACE)) ?? false;
+        public bool IsCollection(Compilation compilation) =>
+            (symbol as INamedTypeSymbol)?.ContainsInterface(compilation.GetTypeByMetadataName(COLLECTION_INTERFACE)) ?? false;
 
-    public static bool IsList(this ISymbol symbol, Compilation compilation) =>
-        (symbol as INamedTypeSymbol)?.ConstructedFrom.Equals(
-            compilation.GetTypeByMetadataName(LIST_CLASS),
-            SymbolEqualityComparer.Default
-        ) == true;
+        public bool IsList(Compilation compilation) =>
+            (symbol as INamedTypeSymbol)?.ConstructedFrom.Equals(
+                compilation.GetTypeByMetadataName(LIST_CLASS),
+                SymbolEqualityComparer.Default
+            ) == true;
 
-    public static bool IsListInterface(this ISymbol symbol, Compilation compilation) =>
-        (symbol as INamedTypeSymbol)?.ContainsInterface(compilation.GetTypeByMetadataName(LIST_INTERFACE)) ?? false;
+        public bool IsListInterface(Compilation compilation) =>
+            (symbol as INamedTypeSymbol)?.ContainsInterface(compilation.GetTypeByMetadataName(LIST_INTERFACE)) ?? false;
+    }
 
     public static bool IsPrimitiveFromTypeDisplayString(string type) =>
         type is "bool" or "sbyte" or "short" or "int" or "long" or "byte" or "ushort"

--- a/ModernUO.Serialization.Generator/SourceGeneration/SymbolMetadata/SymbolMetadata.Builtin.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SymbolMetadata/SymbolMetadata.Builtin.cs
@@ -28,7 +28,7 @@ public static partial class SymbolMetadata
     public const string HASHSET_CLASS = "System.Collections.Generic.HashSet`1";
     public const string SORTEDSET_CLASS = "System.Collections.Generic.SortedSet`1";
     public const string IPADDRESS_CLASS = "System.Net.IPAddress";
-    public const string KEYVALUEPAIR_STRUCT = "System.Collections.Generic.KeyValuePair";
+    public const string KEYVALUEPAIR_STRUCT = "System.Collections.Generic.KeyValuePair`2";
     public const string TIMESPAN_STRUCT = "System.TimeSpan";
     public const string DATETIME_STRUCT = "System.DateTime";
     public const string GUID_STRUCT = "System.Guid";

--- a/ModernUO.Serialization.Generator/SourceGeneration/SymbolMetadata/SymbolMetadata.UO.cs
+++ b/ModernUO.Serialization.Generator/SourceGeneration/SymbolMetadata/SymbolMetadata.UO.cs
@@ -37,6 +37,7 @@ public static partial class SymbolMetadata
     public const string SERIALIZABLE_FIELD_SAVE_FLAG_ATTRIBUTE = "ModernUO.Serialization.SerializableFieldSaveFlagAttribute";
     public const string SERIALIZABLE_FIELD_DEFAULT_ATTRIBUTE = "ModernUO.Serialization.SerializableFieldDefaultAttribute";
     public const string SERIALIZED_PROPERTY_ATTR_ATTRIBUTE = "ModernUO.Serialization.SerializedPropertyAttrAttribute`1";
+    public const string SORTED_SET_COMPARER_ATTRIBUTE = "ModernUO.Serialization.SortedSetComparerAttribute";
 
     public const string SERIALIZABLE_INTERFACE = "Server.ISerializable";
     public const string GENERIC_WRITER_INTERFACE = "Server.IGenericWriter";
@@ -55,329 +56,447 @@ public static partial class SymbolMetadata
     // ModernUO modified BitArray
     public const string BITARRAY_CLASS = "System.Collections.BitArray";
 
-    public static bool IsSerializedPropertyAttr(this AttributeData attr, Compilation compilation, out ITypeSymbol? genericType)
+    extension(AttributeData attr)
     {
-        var attrClass = attr?.AttributeClass;
-        if (attrClass?.BaseType == null || attrClass.BaseType.IsUnboundGenericType || !attrClass.BaseType.IsGenericType)
+        public bool IsSerializedPropertyAttr(Compilation compilation, out ITypeSymbol genericType)
         {
-            genericType = null;
-            return false;
+            var attrClass = attr?.AttributeClass;
+            if (attrClass?.BaseType == null || attrClass.BaseType.IsUnboundGenericType || !attrClass.BaseType.IsGenericType)
+            {
+                genericType = null;
+                return false;
+            }
+
+            var serializedPropertyAttrType = compilation.GetTypeByMetadataName(SERIALIZED_PROPERTY_ATTR_ATTRIBUTE);
+            if (!attrClass.BaseType.ConstructedFrom.Equals(serializedPropertyAttrType, SymbolEqualityComparer.Default))
+            {
+                genericType = null;
+                return false;
+            }
+
+            var types = attrClass.BaseType.TypeArguments;
+            if (types.Length != 1)
+            {
+                genericType = null;
+                return false;
+            }
+
+            genericType = types[0];
+            return true;
         }
 
-        var serializedPropertyAttrType = compilation.GetTypeByMetadataName(SERIALIZED_PROPERTY_ATTR_ATTRIBUTE);
-        if (!attrClass.BaseType.ConstructedFrom.Equals(serializedPropertyAttrType, SymbolEqualityComparer.Default))
-        {
-            genericType = null;
-            return false;
-        }
+        public bool IsCanBeNull(Compilation compilation) =>
+            attr?.IsAttribute(compilation.GetTypeByMetadataName(CAN_BE_NULL_ATTRIBUTE)) == true;
 
-        var types = attrClass.BaseType.TypeArguments;
-        if (types.Length != 1)
-        {
-            genericType = null;
-            return false;
-        }
-
-        genericType = types[0];
-        return true;
+        public bool IsTimerDrift(Compilation compilation) =>
+            attr?.IsAttribute(compilation.GetTypeByMetadataName(TIMER_DRIFT_ATTRIBUTE)) == true;
     }
-
-    public static bool IsCanBeNull(this AttributeData attr, Compilation compilation) =>
-        attr?.IsAttribute(compilation.GetTypeByMetadataName(CAN_BE_NULL_ATTRIBUTE)) == true;
-
-    public static bool IsTimerDrift(this AttributeData attr, Compilation compilation) =>
-        attr?.IsAttribute(compilation.GetTypeByMetadataName(TIMER_DRIFT_ATTRIBUTE)) == true;
 
     public static bool IsTimer(this ITypeSymbol symbol, Compilation compilation) =>
         symbol.CanBeConstructedFrom(compilation.GetTypeByMetadataName(TIMER_CLASS));
 
-    public static bool IsEncodedInt(this AttributeData attr, Compilation compilation) =>
-        attr?.IsAttribute(compilation.GetTypeByMetadataName(ENCODED_INT_ATTRIBUTE)) == true;
+    extension(AttributeData attr)
+    {
+        public bool IsEncodedInt(Compilation compilation) =>
+            attr?.IsAttribute(compilation.GetTypeByMetadataName(ENCODED_INT_ATTRIBUTE)) == true;
 
-    public static bool IsDeltaDateTime(this AttributeData attr, Compilation compilation) =>
-        attr?.IsAttribute(compilation.GetTypeByMetadataName(DELTA_DATE_TIME_ATTRIBUTE)) == true;
+        public bool IsDeltaDateTime(Compilation compilation) =>
+            attr?.IsAttribute(compilation.GetTypeByMetadataName(DELTA_DATE_TIME_ATTRIBUTE)) == true;
 
-    public static bool IsInternString(this AttributeData attr, Compilation compilation) =>
-        attr?.IsAttribute(compilation.GetTypeByMetadataName(INTERN_STRING_ATTRIBUTE)) == true;
+        public bool IsInternString(Compilation compilation) =>
+            attr?.IsAttribute(compilation.GetTypeByMetadataName(INTERN_STRING_ATTRIBUTE)) == true;
 
-    public static bool IsTidy(this AttributeData attr, Compilation compilation) =>
-        attr?.IsAttribute(compilation.GetTypeByMetadataName(TIDY_ATTRIBUTE)) == true;
+        public bool IsTidy(Compilation compilation) =>
+            attr?.IsAttribute(compilation.GetTypeByMetadataName(TIDY_ATTRIBUTE)) == true;
 
-    public static bool IsAttribute(this AttributeData attr, ISymbol symbol) =>
-        attr?.AttributeClass?.Equals(symbol, SymbolEqualityComparer.Default) == true;
+        public bool IsAttribute(ISymbol symbol) =>
+            attr?.AttributeClass?.Equals(symbol, SymbolEqualityComparer.Default) == true;
 
-    public static bool IsEnum(this ITypeSymbol symbol) =>
-        symbol.SpecialType == SpecialType.System_Enum || symbol.TypeKind == TypeKind.Enum;
+        public bool IsSortedSetComparer(Compilation compilation) =>
+            attr?.IsAttribute(compilation.GetTypeByMetadataName(SORTED_SET_COMPARER_ATTRIBUTE)) == true;
+    }
 
-    public static bool HasSerializableInterface(
-        this ITypeSymbol symbol,
-        Compilation compilation
-    ) => symbol.ContainsInterface(compilation.GetTypeByMetadataName(SERIALIZABLE_INTERFACE));
+    public static bool TryGetSortedSetComparer(
+        this ImmutableArray<AttributeData> attributes,
+        Compilation compilation,
+        out string? comparerExpression
+    )
+    {
+        var sortedSetComparerAttr = compilation.GetTypeByMetadataName(SORTED_SET_COMPARER_ATTRIBUTE);
+        var attr = attributes.FirstOrDefault(a => a.IsAttribute(sortedSetComparerAttr));
+
+        if (attr == null)
+        {
+            comparerExpression = null;
+            return false;
+        }
+
+        var comparerType = attr.ConstructorArguments[0].Value as ITypeSymbol;
+        if (comparerType == null)
+        {
+            comparerExpression = null;
+            return false;
+        }
+
+        var comparerTypeName = comparerType.ToDisplayString();
+
+        if (attr.ConstructorArguments.Length > 1 && attr.ConstructorArguments[1].Value is string staticMember)
+        {
+            // Static member: e.g., "StringComparer.OrdinalIgnoreCase"
+            comparerExpression = $"{comparerTypeName}.{staticMember}";
+        }
+        else
+        {
+            // Instance comparer: e.g., "new MyComparer()"
+            comparerExpression = $"new {comparerTypeName}()";
+        }
+
+        return true;
+    }
+
+    extension(ITypeSymbol symbol)
+    {
+        public bool IsEnum() =>
+            symbol.SpecialType == SpecialType.System_Enum || symbol.TypeKind == TypeKind.Enum;
+
+        public bool HasSerializableInterface(
+            Compilation compilation
+        ) => symbol.ContainsInterface(compilation.GetTypeByMetadataName(SERIALIZABLE_INTERFACE));
+    }
 
     public static bool Contains(this ImmutableArray<INamedTypeSymbol> symbols, ITypeSymbol? symbol) =>
         symbol is INamedTypeSymbol namedSymbol &&
         symbols.Contains(namedSymbol, SymbolEqualityComparer.Default) || symbols.Contains(symbol?.BaseType);
 
-    public static bool HasSerialCtor(
-        this INamedTypeSymbol symbol,
-        Compilation compilation
-    )
+    extension(INamedTypeSymbol symbol)
     {
-        var serialType = compilation.GetTypeByMetadataName(SERIAL_STRUCT);
-        return symbol.Constructors.FirstOrDefault(
-            member =>
-                member.Parameters.Length == 1
-                && SymbolEqualityComparer.Default.Equals(member.Parameters[0].Type, serialType)
-        ) != null;
-    }
+        public bool HasSerialCtor(
+            Compilation compilation
+        )
+        {
+            var serialType = compilation.GetTypeByMetadataName(SERIAL_STRUCT);
+            return symbol.Constructors.FirstOrDefault(
+                member =>
+                    member.Parameters.Length == 1
+                    && SymbolEqualityComparer.Default.Equals(member.Parameters[0].Type, serialType)
+            ) != null;
+        }
 
-    public static bool TryGetEmptyOrParentCtor(
-        this INamedTypeSymbol symbol,
-        INamedTypeSymbol? parentSymbol,
-        out bool requiresParent
-    )
-    {
-        var genericCtor = symbol.Constructors.FirstOrDefault(
-            m =>
-            {
-                if (m.IsStatic || m.MethodKind != MethodKind.Constructor)
+        public bool TryGetEmptyOrParentCtor(
+            INamedTypeSymbol? parentSymbol,
+            out bool requiresParent
+        )
+        {
+            var genericCtor = symbol.Constructors.FirstOrDefault(
+                m =>
                 {
-                    return false;
-                }
-
-                if (m.Parameters.Length == 0)
-                {
-                    return true;
-                }
-
-                if (parentSymbol == null)
-                {
-                    return false;
-                }
-
-                var argType = m.Parameters[0].Type;
-                if (argType.TypeKind == TypeKind.Interface)
-                {
-                    return parentSymbol.Equals(argType, SymbolEqualityComparer.Default) || parentSymbol.ContainsInterface(argType);
-                }
-
-                if (parentSymbol.CanBeConstructedFrom(m.Parameters[0].Type) != true)
-                {
-                    return false;
-                }
-
-                for (var i = 1; i < m.Parameters.Length; i++)
-                {
-                    if (!m.Parameters[i].IsOptional)
+                    if (m.IsStatic || m.MethodKind != MethodKind.Constructor)
                     {
                         return false;
                     }
+
+                    if (m.Parameters.Length == 0)
+                    {
+                        return true;
+                    }
+
+                    if (parentSymbol == null)
+                    {
+                        return false;
+                    }
+
+                    var argType = m.Parameters[0].Type;
+                    if (argType.TypeKind == TypeKind.Interface)
+                    {
+                        return parentSymbol.Equals(argType, SymbolEqualityComparer.Default) || parentSymbol.ContainsInterface(argType);
+                    }
+
+                    if (parentSymbol.CanBeConstructedFrom(m.Parameters[0].Type) != true)
+                    {
+                        return false;
+                    }
+
+                    for (var i = 1; i < m.Parameters.Length; i++)
+                    {
+                        if (!m.Parameters[i].IsOptional)
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
                 }
-
-                return true;
-            }
-        );
-
-        requiresParent = genericCtor?.Parameters.Length > 0;
-        return genericCtor != null;
-    }
-
-    public static bool HasGenericReaderCtor(
-        this INamedTypeSymbol symbol,
-        Compilation compilation,
-        ISymbol? parentSymbol,
-        out bool requiresParent
-    )
-    {
-        var genericReaderInterface = compilation.GetTypeByMetadataName(GENERIC_READER_INTERFACE);
-        var genericCtor = symbol.Constructors.FirstOrDefault(
-            m => !m.IsStatic &&
-                 m.MethodKind == MethodKind.Constructor &&
-                 m.Parameters.Length >= 1 &&
-                 m.Parameters.Length <= 2 &&
-                 SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, genericReaderInterface)
-        );
-
-        requiresParent = genericCtor?.Parameters.Length == 2 && SymbolEqualityComparer.Default.Equals(genericCtor.Parameters[1].Type, parentSymbol);
-        return genericCtor != null;
-    }
-
-    public static string? GetMarkDirtyMethod(
-        this ITypeSymbol symbol, bool isSerializable = true, string? dirtyTrackingEntity = null, bool dirtyCanBeNull = false
-    )
-    {
-        var markDirtyMethod = symbol.GetAllMethods("MarkDirty")
-            .FirstOrDefault(
-                m => !m.IsStatic &&
-                     m.ReturnsVoid &&
-                     m.Parameters.Length == 0 &&
-                     m.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal
             );
 
-        if (markDirtyMethod != null)
-        {
-            var dirtyTrackingEntityName =
-                dirtyTrackingEntity != null ? $"{dirtyTrackingEntity}{(dirtyCanBeNull ? "?" : "")}." : "";
-            return $"{dirtyTrackingEntityName}{markDirtyMethod.ToDisplayString()}()";
+            requiresParent = genericCtor?.Parameters.Length > 0;
+            return genericCtor != null;
         }
 
-        return isSerializable switch
+        public bool HasGenericReaderCtor(
+            Compilation compilation,
+            ISymbol? parentSymbol,
+            out bool requiresParent
+        )
         {
-            true => $"Server.ISerializableExtensions.MarkDirty({dirtyTrackingEntity ?? "this"})",
-            _    => null
-        };
-    }
-
-    public static bool HasPublicSerializeMethod(this ITypeSymbol symbol, Compilation compilation)
-    {
-        var genericWriterInterface = compilation.GetTypeByMetadataName(GENERIC_WRITER_INTERFACE);
-
-        return symbol.GetAllMethods("Serialize")
-            .Any(
+            var genericReaderInterface = compilation.GetTypeByMetadataName(GENERIC_READER_INTERFACE);
+            var genericCtor = symbol.Constructors.FirstOrDefault(
                 m => !m.IsStatic &&
-                     m.ReturnsVoid &&
-                     m.Parameters.Length == 1 &&
-                     SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, genericWriterInterface) &&
-                     m.DeclaredAccessibility == Accessibility.Public
-            );
-    }
-
-    public static bool HasPublicDeserializeMethod(
-        this ITypeSymbol symbol,
-        Compilation compilation
-    )
-    {
-        var genericReaderInterface = compilation.GetTypeByMetadataName(GENERIC_READER_INTERFACE);
-
-        return symbol.GetAllMethods("Deserialize")
-            .Any(
-                m => !m.IsStatic &&
-                     m.ReturnsVoid &&
-                     m.Parameters.Length == 1 &&
-                     SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, genericReaderInterface) &&
-                     m.DeclaredAccessibility == Accessibility.Public
-            );
-    }
-
-    public static ISymbol? HasDirtyTrackingEntity(this ITypeSymbol symbol, Compilation compilation) =>
-        symbol.GetMembers().FirstOrDefault(member => member.TryGetDirtyTrackingEntityField(compilation)) ??
-        symbol.BaseType?.HasDirtyTrackingEntity(compilation);
-
-    public static bool IsTextDefinition(this ISymbol symbol, Compilation compilation) =>
-        symbol.IsTypeRecurse(compilation, compilation.GetTypeByMetadataName(TEXTDEFINITION_CLASS));
-
-    public static bool IsPoison(this ISymbol symbol, Compilation compilation) =>
-        symbol.IsTypeRecurse(compilation, compilation.GetTypeByMetadataName(POISON_CLASS));
-
-    public static bool IsPoint2D(this ISymbol symbol, Compilation compilation) =>
-        symbol.Equals(
-            compilation.GetTypeByMetadataName(POINT2D_STRUCT),
-            SymbolEqualityComparer.Default
-        );
-
-    public static bool IsPoint3D(this ISymbol symbol, Compilation compilation) =>
-        symbol.Equals(
-            compilation.GetTypeByMetadataName(POINT3D_STRUCT),
-            SymbolEqualityComparer.Default
-        );
-
-    public static bool IsRectangle2D(this ISymbol symbol, Compilation compilation) =>
-        symbol.Equals(
-            compilation.GetTypeByMetadataName(RECTANGLE2D_STRUCT),
-            SymbolEqualityComparer.Default
-        );
-
-    public static bool IsRectangle3D(this ISymbol symbol, Compilation compilation) =>
-        symbol.Equals(
-            compilation.GetTypeByMetadataName(RECTANGLE3D_STRUCT),
-            SymbolEqualityComparer.Default
-        );
-
-    public static bool IsRace(this ISymbol symbol, Compilation compilation) =>
-        symbol.IsTypeRecurse(compilation, compilation.GetTypeByMetadataName(RACE_CLASS));
-
-    public static bool IsMap(this ISymbol symbol, Compilation compilation) =>
-        symbol.Equals(
-            compilation.GetTypeByMetadataName(MAP_CLASS),
-            SymbolEqualityComparer.Default
-        );
-
-    public static bool IsBitArray(this ISymbol symbol, Compilation compilation) =>
-        symbol.Equals(
-            compilation.GetTypeByMetadataName(BITARRAY_CLASS),
-            SymbolEqualityComparer.Default
-        );
-
-    public static bool IsSerial(this ISymbol symbol, Compilation compilation) =>
-        symbol.Equals(
-            compilation.GetTypeByMetadataName(SERIAL_STRUCT),
-            SymbolEqualityComparer.Default
-        );
-
-    public static AttributeData? GetAttribute(this ISymbol symbol, ISymbol attrSymbol) =>
-        symbol
-            .GetAttributes()
-            .FirstOrDefault(
-                ad => ad.AttributeClass != null && SymbolEqualityComparer.Default.Equals(ad.AttributeClass, attrSymbol)
+                     m.MethodKind == MethodKind.Constructor &&
+                     m.Parameters.Length >= 1 &&
+                     m.Parameters.Length <= 2 &&
+                     SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, genericReaderInterface)
             );
 
-    public static bool HasSerializableInterface(this INamedTypeSymbol classSymbol, Compilation compilation) =>
-        classSymbol.ContainsInterface(compilation.GetTypeByMetadataName(SERIALIZABLE_INTERFACE));
-
-    public static bool IsSerializableRecursive(this INamedTypeSymbol classSymbol, Compilation compilation) =>
-        classSymbol.TryGetSerializable(compilation, out _) ||
-        (classSymbol.BaseType?.IsSerializableRecursive(compilation) ?? false);
-
-    public static bool TryGetSerializable(
-        this INamedTypeSymbol classSymbol, Compilation compilation, out AttributeData? attributeData
-    )
-    {
-        var serializableEntityAttribute =
-            compilation.GetTypeByMetadataName(SERIALIZABLE_ATTRIBUTE);
-
-        attributeData = classSymbol.GetAttribute(serializableEntityAttribute);
-        return attributeData != null;
+            requiresParent = genericCtor?.Parameters.Length == 2 && SymbolEqualityComparer.Default.Equals(genericCtor.Parameters[1].Type, parentSymbol);
+            return genericCtor != null;
+        }
     }
 
-    public static bool TryGetMemberWithAttribute(
-        this ISymbol symbol, INamedTypeSymbol attributeSymbol, out AttributeData? attributeData
-    )
+    extension(ITypeSymbol symbol)
     {
-        attributeData = symbol.GetAttribute(attributeSymbol);
-        return attributeData != null;
+        public string GetMarkDirtyMethod(
+            bool isSerializable = true, string dirtyTrackingEntity = null, bool dirtyCanBeNull = false
+        )
+        {
+            var markDirtyMethod = symbol.GetAllMethods("MarkDirty")
+                .FirstOrDefault(
+                    m => !m.IsStatic &&
+                         m.ReturnsVoid &&
+                         m.Parameters.Length == 0 &&
+                         m.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal
+                );
+
+            if (markDirtyMethod != null)
+            {
+                var dirtyTrackingEntityName =
+                    dirtyTrackingEntity != null ? $"{dirtyTrackingEntity}{(dirtyCanBeNull ? "?" : "")}." : "";
+                return $"{dirtyTrackingEntityName}{markDirtyMethod.ToDisplayString()}()";
+            }
+
+            return isSerializable switch
+            {
+                true => $"Server.ISerializableExtensions.MarkDirty({dirtyTrackingEntity ?? "this"})",
+                _    => null
+            };
+        }
+
+        public bool HasPublicSerializeMethod(Compilation compilation)
+        {
+            var genericWriterInterface = compilation.GetTypeByMetadataName(GENERIC_WRITER_INTERFACE);
+
+            return symbol.GetAllMethods("Serialize")
+                .Any(
+                    m => !m.IsStatic &&
+                         m.ReturnsVoid &&
+                         m.Parameters.Length == 1 &&
+                         SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, genericWriterInterface) &&
+                         m.DeclaredAccessibility == Accessibility.Public
+                );
+        }
+
+        public bool HasPublicDeserializeMethod(
+            Compilation compilation
+        )
+        {
+            var genericReaderInterface = compilation.GetTypeByMetadataName(GENERIC_READER_INTERFACE);
+
+            return symbol.GetAllMethods("Deserialize")
+                .Any(
+                    m => !m.IsStatic &&
+                         m.ReturnsVoid &&
+                         m.Parameters.Length == 1 &&
+                         SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, genericReaderInterface) &&
+                         m.DeclaredAccessibility == Accessibility.Public
+                );
+        }
+
+        public ISymbol? HasDirtyTrackingEntity(Compilation compilation) =>
+            symbol.GetMembers().FirstOrDefault(member => member.TryGetDirtyTrackingEntityField(compilation)) ??
+            symbol.BaseType?.HasDirtyTrackingEntity(compilation);
     }
 
-    public static bool TryGetSerializableField(
-        this ISymbol fieldSymbol, Compilation compilation, out AttributeData? attributeData
-    ) => fieldSymbol.TryGetMemberWithAttribute(
-        compilation.GetTypeByMetadataName(SERIALIZABLE_FIELD_ATTRIBUTE),
-        out attributeData
-    );
+    extension(ISymbol symbol)
+    {
+        public bool IsTextDefinition(Compilation compilation) =>
+            symbol.IsTypeRecurse(compilation, compilation.GetTypeByMetadataName(TEXTDEFINITION_CLASS));
 
-    public static bool TryGetSerializableProperty(
-        this ISymbol propertySymbol, Compilation compilation, out AttributeData? attributeData
-    ) => propertySymbol.TryGetMemberWithAttribute(
-        compilation.GetTypeByMetadataName(SERIALIZABLE_PROPERTY_ATTRIBUTE),
-        out attributeData
-    );
+        public bool IsPoison(Compilation compilation) =>
+            symbol.IsTypeRecurse(compilation, compilation.GetTypeByMetadataName(POISON_CLASS));
 
-    public static bool TryGetDirtyTrackingEntityField(this ISymbol fieldSymbol, Compilation compilation) =>
-        fieldSymbol.TryGetMemberWithAttribute(
-            compilation.GetTypeByMetadataName(DIRTY_TRACKING_ENTITY_ATTRIBUTE),
-            out _
+        public bool IsPoint2D(Compilation compilation) =>
+            symbol.Equals(
+                compilation.GetTypeByMetadataName(POINT2D_STRUCT),
+                SymbolEqualityComparer.Default
+            );
+
+        public bool IsPoint3D(Compilation compilation) =>
+            symbol.Equals(
+                compilation.GetTypeByMetadataName(POINT3D_STRUCT),
+                SymbolEqualityComparer.Default
+            );
+
+        public bool IsRectangle2D(Compilation compilation) =>
+            symbol.Equals(
+                compilation.GetTypeByMetadataName(RECTANGLE2D_STRUCT),
+                SymbolEqualityComparer.Default
+            );
+
+        public bool IsRectangle3D(Compilation compilation) =>
+            symbol.Equals(
+                compilation.GetTypeByMetadataName(RECTANGLE3D_STRUCT),
+                SymbolEqualityComparer.Default
+            );
+
+        public bool IsRace(Compilation compilation) =>
+            symbol.IsTypeRecurse(compilation, compilation.GetTypeByMetadataName(RACE_CLASS));
+
+        public bool IsMap(Compilation compilation) =>
+            symbol.Equals(
+                compilation.GetTypeByMetadataName(MAP_CLASS),
+                SymbolEqualityComparer.Default
+            );
+
+        public bool IsBitArray(Compilation compilation) =>
+            symbol.Equals(
+                compilation.GetTypeByMetadataName(BITARRAY_CLASS),
+                SymbolEqualityComparer.Default
+            );
+
+        public bool IsSerial(Compilation compilation) =>
+            symbol.Equals(
+                compilation.GetTypeByMetadataName(SERIAL_STRUCT),
+                SymbolEqualityComparer.Default
+            );
+
+        public AttributeData? GetAttribute(ISymbol attrSymbol) =>
+            symbol
+                .GetAttributes()
+                .FirstOrDefault(
+                    ad => ad.AttributeClass != null && SymbolEqualityComparer.Default.Equals(ad.AttributeClass, attrSymbol)
+                );
+    }
+
+    extension(INamedTypeSymbol classSymbol)
+    {
+        public bool HasSerializableInterface(Compilation compilation) =>
+            classSymbol.ContainsInterface(compilation.GetTypeByMetadataName(SERIALIZABLE_INTERFACE));
+
+        public bool IsSerializableRecursive(Compilation compilation) =>
+            classSymbol.TryGetSerializable(compilation, out _) ||
+            (classSymbol.BaseType?.IsSerializableRecursive(compilation) ?? false);
+
+        public bool TryGetSerializable(
+            Compilation compilation, out AttributeData? attributeData
+        )
+        {
+            var serializableEntityAttribute =
+                compilation.GetTypeByMetadataName(SERIALIZABLE_ATTRIBUTE);
+
+            attributeData = classSymbol.GetAttribute(serializableEntityAttribute);
+            return attributeData != null;
+        }
+    }
+
+    extension(ISymbol symbol)
+    {
+        public bool TryGetMemberWithAttribute(
+            INamedTypeSymbol attributeSymbol, out AttributeData attributeData
+        )
+        {
+            attributeData = symbol.GetAttribute(attributeSymbol);
+            return attributeData != null;
+        }
+
+        public bool TryGetSerializableField(
+            Compilation compilation, out AttributeData? attributeData
+        ) => symbol.TryGetMemberWithAttribute(
+            compilation.GetTypeByMetadataName(SERIALIZABLE_FIELD_ATTRIBUTE),
+            out attributeData
         );
 
-    public static bool TryGetSerializableFieldSaveFlagMethod(
-        this ISymbol fieldSymbol, Compilation compilation, out AttributeData? attributeData
-    ) => fieldSymbol.TryGetMemberWithAttribute(
-        compilation.GetTypeByMetadataName(SERIALIZABLE_FIELD_SAVE_FLAG_ATTRIBUTE),
-        out attributeData
-    );
+        public bool TryGetSerializableProperty(
+            Compilation compilation, out AttributeData? attributeData
+        ) => symbol.TryGetMemberWithAttribute(
+            compilation.GetTypeByMetadataName(SERIALIZABLE_PROPERTY_ATTRIBUTE),
+            out attributeData
+        );
 
-    public static bool TryGetSerializableFieldDefaultMethod(
-        this ISymbol fieldSymbol, Compilation compilation, out AttributeData? attributeData
-    ) => fieldSymbol.TryGetMemberWithAttribute(
-        compilation.GetTypeByMetadataName(SERIALIZABLE_FIELD_DEFAULT_ATTRIBUTE),
-        out attributeData
-    );
+        public bool TryGetDirtyTrackingEntityField(Compilation compilation) =>
+            symbol.TryGetMemberWithAttribute(
+                compilation.GetTypeByMetadataName(DIRTY_TRACKING_ENTITY_ATTRIBUTE),
+                out _
+            );
+
+        public bool TryGetSerializableFieldSaveFlagMethod(
+            Compilation compilation, out AttributeData? attributeData
+        ) => symbol.TryGetMemberWithAttribute(
+            compilation.GetTypeByMetadataName(SERIALIZABLE_FIELD_SAVE_FLAG_ATTRIBUTE),
+            out attributeData
+        );
+
+        public bool TryGetSerializableFieldDefaultMethod(
+            Compilation compilation, out AttributeData? attributeData
+        ) => symbol.TryGetMemberWithAttribute(
+            compilation.GetTypeByMetadataName(SERIALIZABLE_FIELD_DEFAULT_ATTRIBUTE),
+            out attributeData
+        );
+    }
+
+    extension(INamedTypeSymbol symbol)
+    {
+        public bool HasStaticDeserializeFactory(
+            Compilation compilation
+        )
+        {
+            var genericReaderInterface = compilation.GetTypeByMetadataName(GENERIC_READER_INTERFACE);
+
+            return symbol.GetMembers("Deserialize")
+                .OfType<IMethodSymbol>()
+                .Any(
+                    m => m.IsStatic &&
+                         m.Parameters.Length == 1 &&
+                         SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, genericReaderInterface) &&
+                         SymbolEqualityComparer.Default.Equals(m.ReturnType, symbol) &&
+                         m.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal
+                );
+        }
+
+        public bool HasInstanceDeserializeMethod(
+            Compilation compilation
+        )
+        {
+            var genericReaderInterface = compilation.GetTypeByMetadataName(GENERIC_READER_INTERFACE);
+
+            return symbol.GetMembers("Deserialize")
+                .OfType<IMethodSymbol>()
+                .Any(
+                    m => !m.IsStatic &&
+                         m.ReturnsVoid &&
+                         m.Parameters.Length == 1 &&
+                         SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, genericReaderInterface) &&
+                         m.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal
+                );
+        }
+
+        public bool HasDeserializationCapability(
+            Compilation compilation,
+            out bool usesStaticFactory
+        )
+        {
+            if (symbol.HasStaticDeserializeFactory(compilation))
+            {
+                usesStaticFactory = true;
+                return true;
+            }
+
+            if (symbol.HasInstanceDeserializeMethod(compilation))
+            {
+                usesStaticFactory = false;
+                return true;
+            }
+
+            usesStaticFactory = false;
+            return false;
+        }
+    }
 }

--- a/ModernUO.Serialization.SchemaGenerator/ModernUO.Serialization.SchemaGenerator.csproj
+++ b/ModernUO.Serialization.SchemaGenerator/ModernUO.Serialization.SchemaGenerator.csproj
@@ -6,8 +6,8 @@
         <Platforms>x64;arm64</Platforms>
         <LangVersion>preview</LangVersion>
         <OutputType>Exe</OutputType>
-        <AssemblyVersion>2.13.0</AssemblyVersion>
-        <PackageVersion>2.13.0</PackageVersion>
+        <AssemblyVersion>2.14.1</AssemblyVersion>
+        <PackageVersion>2.14.1</PackageVersion>
         <PackAsTool>true</PackAsTool>
         <AssemblyName>ModernUOSchemaGenerator</AssemblyName>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -20,11 +20,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-        <PackageReference Include="Microsoft.Build.Locator" Version="1.10.12" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
+        <PackageReference Include="Humanizer.Core" Version="3.0.1" />
+        <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
         <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
+        <!-- Needed for Build.Locator but should not be copied to output -->
+        <PackageReference Include="Microsoft.Build.Framework" Version="18.0.2" ExcludeAssets="runtime" />
         <ProjectReference Include="..\ModernUO.Serialization.Generator\ModernUO.Serialization.Generator.csproj" />
     </ItemGroup>
 </Project>

--- a/SerializationGenerator.sln
+++ b/SerializationGenerator.sln
@@ -6,23 +6,68 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModernUO.Serialization.Sche
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModernUO.Serialization.Annotations", "ModernUO.Serialization.Annotations\ModernUO.Serialization.Annotations.csproj", "{319F65B0-4460-40D3-BF6A-5A55B4FA07E4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModernUO.Serialization.Generator.Tests", "ModernUO.Serialization.Generator.Tests\ModernUO.Serialization.Generator.Tests.csproj", "{E670BC05-D4A9-4959-B645-A44CEA4A4038}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F3D9ABA1-44C4-48D6-A0BC-EE2AC00340CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F3D9ABA1-44C4-48D6-A0BC-EE2AC00340CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3D9ABA1-44C4-48D6-A0BC-EE2AC00340CE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F3D9ABA1-44C4-48D6-A0BC-EE2AC00340CE}.Debug|x64.Build.0 = Debug|Any CPU
+		{F3D9ABA1-44C4-48D6-A0BC-EE2AC00340CE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F3D9ABA1-44C4-48D6-A0BC-EE2AC00340CE}.Debug|x86.Build.0 = Debug|Any CPU
 		{F3D9ABA1-44C4-48D6-A0BC-EE2AC00340CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F3D9ABA1-44C4-48D6-A0BC-EE2AC00340CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F3D9ABA1-44C4-48D6-A0BC-EE2AC00340CE}.Release|x64.ActiveCfg = Release|Any CPU
+		{F3D9ABA1-44C4-48D6-A0BC-EE2AC00340CE}.Release|x64.Build.0 = Release|Any CPU
+		{F3D9ABA1-44C4-48D6-A0BC-EE2AC00340CE}.Release|x86.ActiveCfg = Release|Any CPU
+		{F3D9ABA1-44C4-48D6-A0BC-EE2AC00340CE}.Release|x86.Build.0 = Release|Any CPU
 		{BB6B4E79-ADCB-4E98-A17B-31F37D005DA6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BB6B4E79-ADCB-4E98-A17B-31F37D005DA6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB6B4E79-ADCB-4E98-A17B-31F37D005DA6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BB6B4E79-ADCB-4E98-A17B-31F37D005DA6}.Debug|x64.Build.0 = Debug|Any CPU
+		{BB6B4E79-ADCB-4E98-A17B-31F37D005DA6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BB6B4E79-ADCB-4E98-A17B-31F37D005DA6}.Debug|x86.Build.0 = Debug|Any CPU
 		{BB6B4E79-ADCB-4E98-A17B-31F37D005DA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BB6B4E79-ADCB-4E98-A17B-31F37D005DA6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB6B4E79-ADCB-4E98-A17B-31F37D005DA6}.Release|x64.ActiveCfg = Release|Any CPU
+		{BB6B4E79-ADCB-4E98-A17B-31F37D005DA6}.Release|x64.Build.0 = Release|Any CPU
+		{BB6B4E79-ADCB-4E98-A17B-31F37D005DA6}.Release|x86.ActiveCfg = Release|Any CPU
+		{BB6B4E79-ADCB-4E98-A17B-31F37D005DA6}.Release|x86.Build.0 = Release|Any CPU
 		{319F65B0-4460-40D3-BF6A-5A55B4FA07E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{319F65B0-4460-40D3-BF6A-5A55B4FA07E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{319F65B0-4460-40D3-BF6A-5A55B4FA07E4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{319F65B0-4460-40D3-BF6A-5A55B4FA07E4}.Debug|x64.Build.0 = Debug|Any CPU
+		{319F65B0-4460-40D3-BF6A-5A55B4FA07E4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{319F65B0-4460-40D3-BF6A-5A55B4FA07E4}.Debug|x86.Build.0 = Debug|Any CPU
 		{319F65B0-4460-40D3-BF6A-5A55B4FA07E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{319F65B0-4460-40D3-BF6A-5A55B4FA07E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{319F65B0-4460-40D3-BF6A-5A55B4FA07E4}.Release|x64.ActiveCfg = Release|Any CPU
+		{319F65B0-4460-40D3-BF6A-5A55B4FA07E4}.Release|x64.Build.0 = Release|Any CPU
+		{319F65B0-4460-40D3-BF6A-5A55B4FA07E4}.Release|x86.ActiveCfg = Release|Any CPU
+		{319F65B0-4460-40D3-BF6A-5A55B4FA07E4}.Release|x86.Build.0 = Release|Any CPU
+		{E670BC05-D4A9-4959-B645-A44CEA4A4038}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E670BC05-D4A9-4959-B645-A44CEA4A4038}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E670BC05-D4A9-4959-B645-A44CEA4A4038}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E670BC05-D4A9-4959-B645-A44CEA4A4038}.Debug|x64.Build.0 = Debug|Any CPU
+		{E670BC05-D4A9-4959-B645-A44CEA4A4038}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E670BC05-D4A9-4959-B645-A44CEA4A4038}.Debug|x86.Build.0 = Debug|Any CPU
+		{E670BC05-D4A9-4959-B645-A44CEA4A4038}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E670BC05-D4A9-4959-B645-A44CEA4A4038}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E670BC05-D4A9-4959-B645-A44CEA4A4038}.Release|x64.ActiveCfg = Release|Any CPU
+		{E670BC05-D4A9-4959-B645-A44CEA4A4038}.Release|x64.Build.0 = Release|Any CPU
+		{E670BC05-D4A9-4959-B645-A44CEA4A4038}.Release|x86.ActiveCfg = Release|Any CPU
+		{E670BC05-D4A9-4959-B645-A44CEA4A4038}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
### Summary

* Adds better `SaveFlag` support.
* Fixes `SortedSet` support.
* Adds custom comparer support for `SortedSet`.
* Fixes various bugs.
* Adds support for `struct`, `record`, and `generic` classes.
* Adds support for `readonly` fields by skipping serializaton entirely.
* Adds support for interface fields that inherit ISerializable
* Adds tests.

Closes #30